### PR TITLE
feat(user): 사용자 도메인 기본 구조 구현

### DIFF
--- a/src/main/java/com/chaerok/backend/user/entity/OAuthProvider.java
+++ b/src/main/java/com/chaerok/backend/user/entity/OAuthProvider.java
@@ -1,0 +1,6 @@
+package com.chaerok.backend.user.entity;
+
+public enum OAuthProvider {
+    KAKAO,
+    GOOGLE
+}

--- a/src/main/java/com/chaerok/backend/user/entity/User.java
+++ b/src/main/java/com/chaerok/backend/user/entity/User.java
@@ -43,6 +43,10 @@ public class User {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole role;
+
     private User(
             OAuthProvider provider,
             String providerUserId,
@@ -53,6 +57,7 @@ public class User {
         this.providerUserId = providerUserId;
         this.nickname = nickname;
         this.email = email;
+        this.role = UserRole.USER;
     }
 
     public static User create(

--- a/src/main/java/com/chaerok/backend/user/entity/User.java
+++ b/src/main/java/com/chaerok/backend/user/entity/User.java
@@ -1,0 +1,70 @@
+package com.chaerok.backend.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_users_provider_provider_user_id",
+                        columnNames = {"provider", "provider_user_id"}
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OAuthProvider provider;
+
+    @Column(name = "provider_user_id", nullable = false)
+    private String providerUserId;
+
+    @Column(nullable = false, length = 30)
+    private String nickname;
+
+    @Column
+    private String email;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private User(
+            OAuthProvider provider,
+            String providerUserId,
+            String nickname,
+            String email
+    ) {
+        this.provider = provider;
+        this.providerUserId = providerUserId;
+        this.nickname = nickname;
+        this.email = email;
+    }
+
+    public static User create(
+            OAuthProvider provider,
+            String providerUserId,
+            String nickname,
+            String email
+    ) {
+        return new User(provider, providerUserId, nickname, email);
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/chaerok/backend/user/entity/UserRole.java
+++ b/src/main/java/com/chaerok/backend/user/entity/UserRole.java
@@ -1,0 +1,6 @@
+package com.chaerok.backend.user.entity;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/chaerok/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/chaerok/backend/user/repository/UserRepository.java
@@ -1,0 +1,20 @@
+package com.chaerok.backend.user.repository;
+
+import com.chaerok.backend.user.entity.OAuthProvider;
+import com.chaerok.backend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByProviderAndProviderUserId(
+            OAuthProvider provider,
+            String providerUserId
+    );
+
+    boolean existsByProviderAndProviderUserId(
+            OAuthProvider provider,
+            String providerUserId
+    );
+}

--- a/src/main/java/com/chaerok/backend/user/service/UserService.java
+++ b/src/main/java/com/chaerok/backend/user/service/UserService.java
@@ -1,0 +1,66 @@
+package com.chaerok.backend.user.service;
+
+import com.chaerok.backend.user.entity.OAuthProvider;
+import com.chaerok.backend.user.entity.User;
+import com.chaerok.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User findById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() ->
+                        new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+    }
+
+    public Optional<User> findByOAuthProvider(
+            OAuthProvider provider,
+            String providerUserId
+    ) {
+        return userRepository.findByProviderAndProviderUserId(
+                provider,
+                providerUserId
+        );
+    }
+
+    @Transactional
+    public User createUser(
+            OAuthProvider provider,
+            String providerUserId,
+            String nickname,
+            String email
+    ) {
+        if (userRepository.existsByProviderAndProviderUserId(
+                provider,
+                providerUserId
+        )) {
+            throw new IllegalArgumentException("이미 가입된 사용자입니다.");
+        }
+
+        User user = User.create(
+                provider,
+                providerUserId,
+                nickname,
+                email
+        );
+
+        return userRepository.save(user);
+    }
+
+    @Transactional
+    public User updateNickname(Long userId, String nickname) {
+        User user = findById(userId);
+        user.updateNickname(nickname);
+
+        return user;
+    }
+}


### PR DESCRIPTION
## ✨ 변경 사항

---

* User 엔티티 구현
* OAuthProvider, UserRole enum 추가
* UserRepository 구현
* UserService 구현
* OAuth 제공자와 제공자 사용자 ID 복합 유니크 제약 추가
* 닉네임 수정 기능 추가

## 📌 담당 영역

---

* [ ] 공통 설정 / 인프라
* [x] Backend 1: 사용자·관광 데이터·코스/Odii
* [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
* [x] DB / Supabase
* [ ] 문서 / 기타

## 🔗 관련 이슈

---

* 없음

## 🧩 API / DB 변경 사항

---

* `users` 테이블 생성
* 컬럼 추가

  * `id`
  * `provider`
  * `provider_user_id`
  * `nickname`
  * `email`
  * `role`
  * `created_at`
* `provider`, `provider_user_id` 복합 유니크 제약 추가
* API 변경 없음

## ✅ 테스트

---

* [x] 서버 실행 확인
* [x] Swagger 확인
* [x] 수동 테스트 완료
* [ ] 해당 없음

## 💬 참고 사항

---

* OAuth 로그인은 카카오 OIDC ID Token과 구글 ID Token 방식으로 구현 예정
* 신규 사용자의 기본 권한은 `USER`로 설정
* 관리자 권한 변경 API는 현재 범위에 포함하지 않음
