### PR TITLE
feat(auth): OAuth 로그인과 JWT 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/chaerok/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/chaerok/backend/auth/controller/AuthController.java
@@ -1,0 +1,52 @@
+package com.chaerok.backend.auth.controller;
+
+import com.chaerok.backend.auth.dto.*;
+import com.chaerok.backend.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<OAuthLoginResponse> login(
+            @Valid @RequestBody OAuthLoginRequest request
+    ) {
+        OAuthLoginResponse response = authService.login(request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<TokenResponse> signup(
+            @Valid @RequestBody SignupRequest request
+    ) {
+        TokenResponse response = authService.signup(request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(
+            @Valid @RequestBody RefreshTokenRequest request
+    ) {
+        TokenResponse response = authService.refresh(request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @Valid @RequestBody RefreshTokenRequest request
+    ) {
+        authService.logout(request);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/chaerok/backend/auth/dto/OAuthLoginRequest.java
+++ b/src/main/java/com/chaerok/backend/auth/dto/OAuthLoginRequest.java
@@ -1,0 +1,15 @@
+package com.chaerok.backend.auth.dto;
+
+import com.chaerok.backend.user.entity.OAuthProvider;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record OAuthLoginRequest(
+
+        @NotNull(message = "OAuth 제공자는 필수입니다.")
+        OAuthProvider provider,
+
+        @NotBlank(message = "ID Token은 필수입니다.")
+        String idToken
+) {
+}

--- a/src/main/java/com/chaerok/backend/auth/dto/OAuthLoginResponse.java
+++ b/src/main/java/com/chaerok/backend/auth/dto/OAuthLoginResponse.java
@@ -1,0 +1,27 @@
+package com.chaerok.backend.auth.dto;
+
+public record OAuthLoginResponse(
+        boolean registered,
+        TokenResponse tokens,
+        String signupToken
+) {
+
+    public static OAuthLoginResponse existingUser(
+            String accessToken,
+            String refreshToken
+    ) {
+        return new OAuthLoginResponse(
+                true,
+                new TokenResponse(accessToken, refreshToken),
+                null
+        );
+    }
+
+    public static OAuthLoginResponse newUser(String signupToken) {
+        return new OAuthLoginResponse(
+                false,
+                null,
+                signupToken
+        );
+    }
+}

--- a/src/main/java/com/chaerok/backend/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/chaerok/backend/auth/dto/RefreshTokenRequest.java
@@ -1,0 +1,10 @@
+package com.chaerok.backend.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenRequest(
+
+        @NotBlank(message = "Refresh Token은 필수입니다.")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/chaerok/backend/auth/dto/SignupRequest.java
+++ b/src/main/java/com/chaerok/backend/auth/dto/SignupRequest.java
@@ -1,0 +1,18 @@
+package com.chaerok.backend.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequest(
+
+        @NotBlank(message = "회원가입 토큰은 필수입니다.")
+        String signupToken,
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(
+                max = 30,
+                message = "닉네임은 30자 이하여야 합니다."
+        )
+        String nickname
+) {
+}

--- a/src/main/java/com/chaerok/backend/auth/dto/TokenResponse.java
+++ b/src/main/java/com/chaerok/backend/auth/dto/TokenResponse.java
@@ -1,0 +1,7 @@
+package com.chaerok.backend.auth.dto;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/chaerok/backend/auth/entity/RefreshToken.java
+++ b/src/main/java/com/chaerok/backend/auth/entity/RefreshToken.java
@@ -1,0 +1,62 @@
+package com.chaerok.backend.auth.entity;
+
+import com.chaerok.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(
+        name = "refresh_tokens",
+        indexes = {
+                @Index(
+                        name = "idx_refresh_tokens_token_hash",
+                        columnList = "token_hash",
+                        unique = true
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "token_hash", nullable = false, unique = true, length = 64)
+    private String tokenHash;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private RefreshToken(
+            User user,
+            String tokenHash,
+            LocalDateTime expiresAt
+    ) {
+        this.user = user;
+        this.tokenHash = tokenHash;
+        this.expiresAt = expiresAt;
+    }
+
+    public static RefreshToken create(
+            User user,
+            String tokenHash,
+            LocalDateTime expiresAt
+    ) {
+        return new RefreshToken(user, tokenHash, expiresAt);
+    }
+}

--- a/src/main/java/com/chaerok/backend/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/chaerok/backend/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,238 @@
+package com.chaerok.backend.auth.jwt;
+
+import com.chaerok.backend.global.exception.InvalidTokenException;
+import com.chaerok.backend.user.entity.OAuthProvider;
+import com.chaerok.backend.user.entity.UserRole;
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.*;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Component
+public class JwtTokenProvider {
+
+    private static final String ISSUER = "chaerok";
+
+    private final JwtEncoder jwtEncoder;
+    private final JwtDecoder jwtDecoder;
+    private final long accessExpiration;
+    private final long refreshExpiration;
+    private final long signupExpiration;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-expiration}") long accessExpiration,
+            @Value("${jwt.refresh-expiration}") long refreshExpiration,
+            @Value("${jwt.signup-expiration}") long signupExpiration
+    ) {
+        SecretKey secretKey = new SecretKeySpec(
+                secret.getBytes(StandardCharsets.UTF_8),
+                "HmacSHA256"
+        );
+
+        this.jwtEncoder = new NimbusJwtEncoder(
+                new ImmutableSecret<>(secretKey)
+        );
+
+        this.jwtDecoder = NimbusJwtDecoder
+                .withSecretKey(secretKey)
+                .macAlgorithm(MacAlgorithm.HS256)
+                .build();
+
+        this.accessExpiration = accessExpiration;
+        this.refreshExpiration = refreshExpiration;
+        this.signupExpiration = signupExpiration;
+    }
+
+    public String createAccessToken(Long userId, UserRole role) {
+        Instant now = Instant.now();
+        Instant expiresAt = now.plusMillis(accessExpiration);
+
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .issuer(ISSUER)
+                .issuedAt(now)
+                .expiresAt(expiresAt)
+                .subject(String.valueOf(userId))
+                .claim("type", TokenType.ACCESS.name())
+                .claim("role", role.name())
+                .build();
+
+        JwsHeader header = JwsHeader
+                .with(MacAlgorithm.HS256)
+                .type("JWT")
+                .build();
+
+        return jwtEncoder.encode(
+                JwtEncoderParameters.from(header, claims)
+        ).getTokenValue();
+    }
+
+    public String createRefreshToken(Long userId) {
+        Instant now = Instant.now();
+        Instant expiresAt = now.plusMillis(refreshExpiration);
+
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .issuer(ISSUER)
+                .issuedAt(now)
+                .expiresAt(expiresAt)
+                .subject(String.valueOf(userId))
+                .claim("type", TokenType.REFRESH.name())
+                .build();
+
+        JwsHeader header = JwsHeader
+                .with(MacAlgorithm.HS256)
+                .type("JWT")
+                .build();
+
+        return jwtEncoder.encode(
+                JwtEncoderParameters.from(header, claims)
+        ).getTokenValue();
+    }
+
+    public Jwt parseToken(String token) {
+        return jwtDecoder.decode(token);
+    }
+
+    public Long getUserId(String token) {
+        return Long.valueOf(parseToken(token).getSubject());
+    }
+
+    public UserRole getRole(String token) {
+        String role = parseToken(token).getClaimAsString("role");
+        return UserRole.valueOf(role);
+    }
+
+    public boolean isAccessToken(String token) {
+        return hasTokenType(token, TokenType.ACCESS);
+    }
+
+    public boolean isRefreshToken(String token) {
+        return hasTokenType(token, TokenType.REFRESH);
+    }
+
+    private boolean hasTokenType(String token, TokenType tokenType) {
+        String actualType = parseToken(token)
+                .getClaimAsString("type");
+
+        return tokenType.name().equals(actualType);
+    }
+
+    public String createSignupToken(
+            OAuthProvider provider,
+            String providerUserId,
+            String nickname,
+            String email
+    ) {
+        Instant now = Instant.now();
+        Instant expiresAt = now.plusMillis(signupExpiration);
+
+        JwtClaimsSet.Builder claimsBuilder = JwtClaimsSet.builder()
+                .issuer(ISSUER)
+                .issuedAt(now)
+                .expiresAt(expiresAt)
+                .subject(providerUserId)
+                .claim("type", TokenType.SIGNUP.name())
+                .claim("provider", provider.name())
+                .claim("nickname", nickname);
+
+        if (email != null) {
+            claimsBuilder.claim("email", email);
+        }
+
+        JwsHeader header = JwsHeader
+                .with(MacAlgorithm.HS256)
+                .type("JWT")
+                .build();
+
+        return jwtEncoder.encode(
+                JwtEncoderParameters.from(
+                        header,
+                        claimsBuilder.build()
+                )
+        ).getTokenValue();
+    }
+
+    public boolean isSignupToken(String token) {
+        return hasTokenType(token, TokenType.SIGNUP);
+    }
+
+    public SignupTokenInfo getSignupTokenInfo(String token) {
+        try {
+            Jwt jwt = parseToken(token);
+
+            String tokenType = jwt.getClaimAsString("type");
+
+            if (!TokenType.SIGNUP.name().equals(tokenType)) {
+                throw new InvalidTokenException(
+                        "회원가입용 토큰이 아닙니다."
+                );
+            }
+
+            OAuthProvider provider = OAuthProvider.valueOf(
+                    jwt.getClaimAsString("provider")
+            );
+
+            return new SignupTokenInfo(
+                    provider,
+                    jwt.getSubject(),
+                    jwt.getClaimAsString("email")
+            );
+        } catch (JwtException exception) {
+            throw new InvalidTokenException(
+                    "유효하지 않거나 만료된 회원가입 토큰입니다.",
+                    exception
+            );
+        }
+    }
+
+    public Long getRefreshTokenUserId(String token) {
+        try {
+            Jwt jwt = parseToken(token);
+
+            String tokenType = jwt.getClaimAsString("type");
+
+            if (!TokenType.REFRESH.name().equals(tokenType)) {
+                throw new InvalidTokenException(
+                        "Refresh Token이 아닙니다."
+                );
+            }
+
+            return Long.valueOf(jwt.getSubject());
+        } catch (JwtException | NumberFormatException exception) {
+            throw new InvalidTokenException(
+                    "유효하지 않거나 만료된 Refresh Token입니다.",
+                    exception
+            );
+        }
+    }
+
+    public LocalDateTime getExpiration(String token) {
+        try {
+            Instant expiresAt = parseToken(token).getExpiresAt();
+
+            if (expiresAt == null) {
+                throw new InvalidTokenException(
+                        "토큰 만료 시간이 존재하지 않습니다."
+                );
+            }
+
+            return LocalDateTime.ofInstant(
+                    expiresAt,
+                    ZoneId.systemDefault()
+            );
+        } catch (JwtException exception) {
+            throw new InvalidTokenException(
+                    "유효하지 않은 토큰입니다.",
+                    exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/chaerok/backend/auth/jwt/SignupTokenInfo.java
+++ b/src/main/java/com/chaerok/backend/auth/jwt/SignupTokenInfo.java
@@ -1,0 +1,10 @@
+package com.chaerok.backend.auth.jwt;
+
+import com.chaerok.backend.user.entity.OAuthProvider;
+
+public record SignupTokenInfo(
+        OAuthProvider provider,
+        String providerUserId,
+        String email
+) {
+}

--- a/src/main/java/com/chaerok/backend/auth/jwt/TokenHashUtil.java
+++ b/src/main/java/com/chaerok/backend/auth/jwt/TokenHashUtil.java
@@ -1,0 +1,30 @@
+package com.chaerok.backend.auth.jwt;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+@Component
+public class TokenHashUtil {
+
+    public String hash(String token) {
+        try {
+            MessageDigest digest =
+                    MessageDigest.getInstance("SHA-256");
+
+            byte[] hashed = digest.digest(
+                    token.getBytes(StandardCharsets.UTF_8)
+            );
+
+            return HexFormat.of().formatHex(hashed);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(
+                    "토큰 해시 생성에 실패했습니다.",
+                    exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/chaerok/backend/auth/jwt/TokenType.java
+++ b/src/main/java/com/chaerok/backend/auth/jwt/TokenType.java
@@ -1,0 +1,7 @@
+package com.chaerok.backend.auth.jwt;
+
+public enum TokenType {
+    ACCESS,
+    REFRESH,
+    SIGNUP
+}

--- a/src/main/java/com/chaerok/backend/auth/oauth/dto/OAuthUserInfo.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/dto/OAuthUserInfo.java
@@ -1,0 +1,11 @@
+package com.chaerok.backend.auth.oauth.dto;
+
+import com.chaerok.backend.user.entity.OAuthProvider;
+
+public record OAuthUserInfo(
+        OAuthProvider provider,
+        String providerUserId,
+        String nickname,
+        String email
+) {
+}

--- a/src/main/java/com/chaerok/backend/auth/oauth/verifier/GoogleTokenVerifier.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/verifier/GoogleTokenVerifier.java
@@ -1,0 +1,81 @@
+package com.chaerok.backend.auth.oauth.verifier;
+
+import com.chaerok.backend.auth.oauth.dto.OAuthUserInfo;
+import com.chaerok.backend.global.exception.InvalidTokenException;
+import com.chaerok.backend.user.entity.OAuthProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GoogleTokenVerifier implements OAuthTokenVerifier {
+
+    private final JwtDecoder jwtDecoder;
+
+    public GoogleTokenVerifier(
+            @Value("${oauth.google.client-id}") String clientId,
+            @Value("${oauth.google.issuer}") String issuer,
+            @Value("${oauth.google.jwk-set-uri}") String jwkSetUri
+    ) {
+        NimbusJwtDecoder decoder =
+                NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
+
+        OAuth2TokenValidator<Jwt> issuerValidator =
+                JwtValidators.createDefaultWithIssuer(issuer);
+
+        OAuth2TokenValidator<Jwt> audienceValidator = jwt -> {
+            if (jwt.getAudience().contains(clientId)) {
+                return OAuth2TokenValidatorResult.success();
+            }
+
+            OAuth2Error error = new OAuth2Error(
+                    "invalid_token",
+                    "구글 ID Token의 audience가 일치하지 않습니다.",
+                    null
+            );
+
+            return OAuth2TokenValidatorResult.failure(error);
+        };
+
+        decoder.setJwtValidator(
+                new DelegatingOAuth2TokenValidator<>(
+                        issuerValidator,
+                        audienceValidator
+                )
+        );
+
+        this.jwtDecoder = decoder;
+    }
+
+    @Override
+    public OAuthProvider getProvider() {
+        return OAuthProvider.GOOGLE;
+    }
+
+    @Override
+    public OAuthUserInfo verify(String idToken) {
+        try {
+            Jwt jwt = jwtDecoder.decode(idToken);
+
+            return new OAuthUserInfo(
+                    OAuthProvider.GOOGLE,
+                    jwt.getSubject(),
+                    jwt.getClaimAsString("name"),
+                    jwt.getClaimAsString("email")
+            );
+        } catch (JwtException exception) {
+            throw new InvalidTokenException(
+                    "유효하지 않은 구글 ID Token입니다.",
+                    exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/chaerok/backend/auth/oauth/verifier/KakaoTokenVerifier.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/verifier/KakaoTokenVerifier.java
@@ -1,0 +1,81 @@
+package com.chaerok.backend.auth.oauth.verifier;
+
+import com.chaerok.backend.auth.oauth.dto.OAuthUserInfo;
+import com.chaerok.backend.global.exception.InvalidTokenException;
+import com.chaerok.backend.user.entity.OAuthProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KakaoTokenVerifier implements OAuthTokenVerifier {
+
+    private final JwtDecoder jwtDecoder;
+
+    public KakaoTokenVerifier(
+            @Value("${oauth.kakao.client-id}") String clientId,
+            @Value("${oauth.kakao.issuer}") String issuer,
+            @Value("${oauth.kakao.jwk-set-uri}") String jwkSetUri
+    ) {
+        NimbusJwtDecoder decoder =
+                NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
+
+        OAuth2TokenValidator<Jwt> issuerValidator =
+                JwtValidators.createDefaultWithIssuer(issuer);
+
+        OAuth2TokenValidator<Jwt> audienceValidator = jwt -> {
+            if (jwt.getAudience().contains(clientId)) {
+                return OAuth2TokenValidatorResult.success();
+            }
+
+            OAuth2Error error = new OAuth2Error(
+                    "invalid_token",
+                    "카카오 ID Token의 audience가 일치하지 않습니다.",
+                    null
+            );
+
+            return OAuth2TokenValidatorResult.failure(error);
+        };
+
+        decoder.setJwtValidator(
+                new DelegatingOAuth2TokenValidator<>(
+                        issuerValidator,
+                        audienceValidator
+                )
+        );
+
+        this.jwtDecoder = decoder;
+    }
+
+    @Override
+    public OAuthProvider getProvider() {
+        return OAuthProvider.KAKAO;
+    }
+
+    @Override
+    public OAuthUserInfo verify(String idToken) {
+        try {
+            Jwt jwt = jwtDecoder.decode(idToken);
+
+            return new OAuthUserInfo(
+                    OAuthProvider.KAKAO,
+                    jwt.getSubject(),
+                    jwt.getClaimAsString("nickname"),
+                    jwt.getClaimAsString("email")
+            );
+        } catch (JwtException exception) {
+            throw new InvalidTokenException(
+                    "유효하지 않은 카카오 ID Token입니다.",
+                    exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/chaerok/backend/auth/oauth/verifier/OAuthTokenVerifier.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/verifier/OAuthTokenVerifier.java
@@ -1,0 +1,11 @@
+package com.chaerok.backend.auth.oauth.verifier;
+
+import com.chaerok.backend.auth.oauth.dto.OAuthUserInfo;
+import com.chaerok.backend.user.entity.OAuthProvider;
+
+public interface OAuthTokenVerifier {
+
+    OAuthProvider getProvider();
+
+    OAuthUserInfo verify(String idToken);
+}

--- a/src/main/java/com/chaerok/backend/auth/oauth/verifier/OAuthTokenVerifierResolver.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/verifier/OAuthTokenVerifierResolver.java
@@ -1,0 +1,34 @@
+package com.chaerok.backend.auth.oauth.verifier;
+
+import com.chaerok.backend.user.entity.OAuthProvider;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class OAuthTokenVerifierResolver {
+
+    private final Map<OAuthProvider, OAuthTokenVerifier> verifiers;
+
+    public OAuthTokenVerifierResolver(List<OAuthTokenVerifier> verifiers) {
+        this.verifiers = new EnumMap<>(OAuthProvider.class);
+
+        for (OAuthTokenVerifier verifier : verifiers) {
+            this.verifiers.put(verifier.getProvider(), verifier);
+        }
+    }
+
+    public OAuthTokenVerifier resolve(OAuthProvider provider) {
+        OAuthTokenVerifier verifier = verifiers.get(provider);
+
+        if (verifier == null) {
+            throw new IllegalStateException(
+                    "OAuth 검증기가 등록되지 않았습니다: " + provider
+            );
+        }
+
+        return verifier;
+    }
+}

--- a/src/main/java/com/chaerok/backend/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/chaerok/backend/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package com.chaerok.backend.auth.repository;
+
+import com.chaerok.backend.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository
+        extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByTokenHash(String tokenHash);
+
+    void deleteByTokenHash(String tokenHash);
+}

--- a/src/main/java/com/chaerok/backend/auth/security/AuthenticatedUser.java
+++ b/src/main/java/com/chaerok/backend/auth/security/AuthenticatedUser.java
@@ -1,0 +1,9 @@
+package com.chaerok.backend.auth.security;
+
+import com.chaerok.backend.user.entity.UserRole;
+
+public record AuthenticatedUser(
+        Long userId,
+        UserRole role
+) {
+}

--- a/src/main/java/com/chaerok/backend/auth/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/chaerok/backend/auth/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,42 @@
+package com.chaerok.backend.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint
+        implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        objectMapper.writeValue(
+                response.getWriter(),
+                Map.of(
+                        "code", "UNAUTHORIZED",
+                        "message", "인증이 필요합니다."
+                )
+        );
+    }
+}

--- a/src/main/java/com/chaerok/backend/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/chaerok/backend/auth/security/JwtAuthenticationFilter.java
@@ -1,0 +1,85 @@
+package com.chaerok.backend.auth.security;
+
+import com.chaerok.backend.auth.jwt.JwtTokenProvider;
+import com.chaerok.backend.user.entity.UserRole;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String accessToken = resolveAccessToken(request);
+
+        if (accessToken != null) {
+            authenticate(accessToken);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveAccessToken(HttpServletRequest request) {
+        String authorization = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (authorization == null
+                || !authorization.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+
+        return authorization.substring(BEARER_PREFIX.length());
+    }
+
+    private void authenticate(String accessToken) {
+        try {
+            if (!jwtTokenProvider.isAccessToken(accessToken)) {
+                return;
+            }
+
+            Long userId = jwtTokenProvider.getUserId(accessToken);
+            UserRole role = jwtTokenProvider.getRole(accessToken);
+
+            AuthenticatedUser principal =
+                    new AuthenticatedUser(userId, role);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            principal,
+                            null,
+                            List.of(
+                                    new SimpleGrantedAuthority(
+                                            "ROLE_" + role.name()
+                                    )
+                            )
+                    );
+
+            SecurityContextHolder.getContext()
+                    .setAuthentication(authentication);
+
+        } catch (RuntimeException exception) {
+            SecurityContextHolder.clearContext();
+        }
+    }
+}

--- a/src/main/java/com/chaerok/backend/auth/service/AuthService.java
+++ b/src/main/java/com/chaerok/backend/auth/service/AuthService.java
@@ -1,0 +1,201 @@
+package com.chaerok.backend.auth.service;
+
+import com.chaerok.backend.auth.dto.*;
+import com.chaerok.backend.auth.entity.RefreshToken;
+import com.chaerok.backend.auth.jwt.JwtTokenProvider;
+import com.chaerok.backend.auth.jwt.SignupTokenInfo;
+import com.chaerok.backend.auth.oauth.dto.OAuthUserInfo;
+import com.chaerok.backend.auth.oauth.verifier.OAuthTokenVerifier;
+import com.chaerok.backend.auth.oauth.verifier.OAuthTokenVerifierResolver;
+import com.chaerok.backend.global.exception.DuplicateUserException;
+import com.chaerok.backend.global.exception.InvalidTokenException;
+import com.chaerok.backend.user.entity.User;
+import com.chaerok.backend.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final OAuthTokenVerifierResolver verifierResolver;
+    private final UserService userService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    public OAuthLoginResponse login(OAuthLoginRequest request) {
+        OAuthTokenVerifier verifier =
+                verifierResolver.resolve(request.provider());
+
+        OAuthUserInfo oauthUserInfo =
+                verifier.verify(request.idToken());
+
+        Optional<User> existingUser =
+                userService.findByOAuthProvider(
+                        oauthUserInfo.provider(),
+                        oauthUserInfo.providerUserId()
+                );
+
+        if (existingUser.isPresent()) {
+            User user = existingUser.get();
+
+            String accessToken =
+                    jwtTokenProvider.createAccessToken(
+                            user.getId(),
+                            user.getRole()
+                    );
+
+            String refreshToken =
+                    jwtTokenProvider.createRefreshToken(user.getId());
+
+            refreshTokenService.save(
+                    user,
+                    refreshToken,
+                    jwtTokenProvider.getExpiration(refreshToken)
+            );
+
+            return OAuthLoginResponse.existingUser(
+                    accessToken,
+                    refreshToken
+            );
+        }
+
+        String nickname = oauthUserInfo.nickname() != null
+                ? oauthUserInfo.nickname()
+                : "채록 사용자";
+
+        String signupToken =
+                jwtTokenProvider.createSignupToken(
+                        oauthUserInfo.provider(),
+                        oauthUserInfo.providerUserId(),
+                        nickname,
+                        oauthUserInfo.email()
+                );
+
+        return OAuthLoginResponse.newUser(signupToken);
+    }
+
+    @Transactional
+    public TokenResponse signup(SignupRequest request) {
+        SignupTokenInfo tokenInfo =
+                jwtTokenProvider.getSignupTokenInfo(
+                        request.signupToken()
+                );
+
+        Optional<User> existingUser =
+                userService.findByOAuthProvider(
+                        tokenInfo.provider(),
+                        tokenInfo.providerUserId()
+                );
+
+        if (existingUser.isPresent()) {
+            throw new DuplicateUserException(
+                    "이미 가입된 사용자입니다."
+            );
+        }
+
+        User user = userService.createUser(
+                tokenInfo.provider(),
+                tokenInfo.providerUserId(),
+                request.nickname(),
+                tokenInfo.email()
+        );
+
+        String accessToken =
+                jwtTokenProvider.createAccessToken(
+                        user.getId(),
+                        user.getRole()
+                );
+
+        String refreshToken =
+                jwtTokenProvider.createRefreshToken(
+                        user.getId()
+                );
+
+        refreshTokenService.save(
+                user,
+                refreshToken,
+                jwtTokenProvider.getExpiration(refreshToken)
+        );
+
+        return new TokenResponse(
+                accessToken,
+                refreshToken
+        );
+    }
+
+    @Transactional
+    public TokenResponse refresh(RefreshTokenRequest request) {
+        String oldRefreshToken = request.refreshToken();
+
+        Long tokenUserId =
+                jwtTokenProvider.getRefreshTokenUserId(
+                        oldRefreshToken
+                );
+
+        RefreshToken savedToken =
+                refreshTokenService.findValidToken(
+                        oldRefreshToken
+                );
+
+        User user = savedToken.getUser();
+
+        if (!user.getId().equals(tokenUserId)) {
+            throw new InvalidTokenException(
+                    "Refresh Token의 사용자 정보가 일치하지 않습니다."
+            );
+        }
+
+        // 기존 Refresh Token 폐기
+        refreshTokenService.delete(oldRefreshToken);
+
+        String newAccessToken =
+                jwtTokenProvider.createAccessToken(
+                        user.getId(),
+                        user.getRole()
+                );
+
+        String newRefreshToken =
+                jwtTokenProvider.createRefreshToken(
+                        user.getId()
+                );
+
+        refreshTokenService.save(
+                user,
+                newRefreshToken,
+                jwtTokenProvider.getExpiration(newRefreshToken)
+        );
+
+        return new TokenResponse(
+                newAccessToken,
+                newRefreshToken
+        );
+    }
+
+    @Transactional
+    public void logout(RefreshTokenRequest request) {
+        String refreshToken = request.refreshToken();
+
+        Long tokenUserId =
+                jwtTokenProvider.getRefreshTokenUserId(
+                        refreshToken
+                );
+
+        RefreshToken savedToken =
+                refreshTokenService.findValidToken(
+                        refreshToken
+                );
+
+        if (!savedToken.getUser().getId().equals(tokenUserId)) {
+            throw new InvalidTokenException(
+                    "Refresh Token의 사용자 정보가 일치하지 않습니다."
+            );
+        }
+
+        refreshTokenService.delete(refreshToken);
+    }
+}

--- a/src/main/java/com/chaerok/backend/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/chaerok/backend/auth/service/RefreshTokenService.java
@@ -1,0 +1,65 @@
+package com.chaerok.backend.auth.service;
+
+import com.chaerok.backend.auth.entity.RefreshToken;
+import com.chaerok.backend.auth.jwt.TokenHashUtil;
+import com.chaerok.backend.auth.repository.RefreshTokenRepository;
+import com.chaerok.backend.global.exception.InvalidTokenException;
+import com.chaerok.backend.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenHashUtil tokenHashUtil;
+
+    @Transactional
+    public void save(
+            User user,
+            String rawToken,
+            LocalDateTime expiresAt
+    ) {
+        String tokenHash = tokenHashUtil.hash(rawToken);
+
+        RefreshToken refreshToken = RefreshToken.create(
+                user,
+                tokenHash,
+                expiresAt
+        );
+
+        refreshTokenRepository.save(refreshToken);
+    }
+
+    public RefreshToken findValidToken(String rawToken) {
+        String tokenHash = tokenHashUtil.hash(rawToken);
+
+        RefreshToken refreshToken =
+                refreshTokenRepository.findByTokenHash(tokenHash)
+                        .orElseThrow(() ->
+                                new InvalidTokenException(
+                                        "저장되지 않았거나 폐기된 Refresh Token입니다."
+                                )
+                        );
+
+        if (refreshToken.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new InvalidTokenException(
+                    "만료된 Refresh Token입니다."
+            );
+        }
+
+        return refreshToken;
+    }
+
+    @Transactional
+    public void delete(String rawToken) {
+        String tokenHash = tokenHashUtil.hash(rawToken);
+
+        refreshTokenRepository.deleteByTokenHash(tokenHash);
+    }
+}

--- a/src/main/java/com/chaerok/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/chaerok/backend/global/config/SecurityConfig.java
@@ -1,27 +1,64 @@
 package com.chaerok.backend.global.config;
 
+import com.chaerok.backend.auth.security.JwtAuthenticationEntryPoint;
+import com.chaerok.backend.auth.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(
+            HttpSecurity http
+    ) throws Exception {
+
         http
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
+
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(
+                                SessionCreationPolicy.STATELESS
+                        )
+                )
+
+                .exceptionHandling(exception ->
+                        exception.authenticationEntryPoint(
+                                jwtAuthenticationEntryPoint
+                        )
+                )
+
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/health",
+                                "/api/auth/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
-                                "/v3/api-docs/**"
+                                "/v3/api-docs/**",
+                                "/error"
                         ).permitAll()
-                        .anyRequest().permitAll()
+
+                        .requestMatchers("/api/admin/**")
+                        .hasRole("ADMIN")
+
+                        .anyRequest()
+                        .authenticated()
+                )
+
+                .addFilterBefore(
+                        jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class
                 );
 
         return http.build();

--- a/src/main/java/com/chaerok/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/chaerok/backend/global/config/SwaggerConfig.java
@@ -1,19 +1,40 @@
 package com.chaerok.backend.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
+    private static final String SECURITY_SCHEME_NAME = "Bearer Authentication";
+
     @Bean
-    public OpenAPI chaerokOpenAPI() {
+    public OpenAPI openAPI() {
         return new OpenAPI()
                 .info(new Info()
                         .title("Chaerok API")
                         .description("충남 소도시 여행 기록 서비스 채록 백엔드 API")
-                        .version("v1.0.0"));
+                        .version("v1.0.0")
+                )
+                .addSecurityItem(
+                        new SecurityRequirement()
+                                .addList(SECURITY_SCHEME_NAME)
+                )
+                .components(
+                        new Components()
+                                .addSecuritySchemes(
+                                        SECURITY_SCHEME_NAME,
+                                        new SecurityScheme()
+                                                .name(SECURITY_SCHEME_NAME)
+                                                .type(SecurityScheme.Type.HTTP)
+                                                .scheme("bearer")
+                                                .bearerFormat("JWT")
+                                )
+                );
     }
 }

--- a/src/main/java/com/chaerok/backend/global/exception/DuplicateUserException.java
+++ b/src/main/java/com/chaerok/backend/global/exception/DuplicateUserException.java
@@ -1,0 +1,8 @@
+package com.chaerok.backend.global.exception;
+
+public class DuplicateUserException extends RuntimeException {
+
+    public DuplicateUserException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/chaerok/backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/chaerok/backend/global/exception/ErrorResponse.java
@@ -1,0 +1,7 @@
+package com.chaerok.backend.global.exception;
+
+public record ErrorResponse(
+        String code,
+        String message
+) {
+}

--- a/src/main/java/com/chaerok/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chaerok/backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,54 @@
+package com.chaerok.backend.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidToken(
+            InvalidTokenException exception
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(new ErrorResponse(
+                        "INVALID_TOKEN",
+                        exception.getMessage()
+                ));
+    }
+
+    @ExceptionHandler(DuplicateUserException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicateUser(
+            DuplicateUserException exception
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse(
+                        "DUPLICATE_USER",
+                        exception.getMessage()
+                ));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(
+            MethodArgumentNotValidException exception
+    ) {
+        String message = exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(error -> error.getDefaultMessage())
+                .orElse("요청값이 올바르지 않습니다.");
+
+        return ResponseEntity
+                .badRequest()
+                .body(new ErrorResponse(
+                        "INVALID_REQUEST",
+                        message
+                ));
+    }
+}

--- a/src/main/java/com/chaerok/backend/global/exception/InvalidTokenException.java
+++ b/src/main/java/com/chaerok/backend/global/exception/InvalidTokenException.java
@@ -1,0 +1,15 @@
+package com.chaerok.backend.global.exception;
+
+public class InvalidTokenException extends RuntimeException {
+
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+
+    public InvalidTokenException(
+            String message,
+            Throwable cause
+    ) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/chaerok/backend/user/controller/UserController.java
+++ b/src/main/java/com/chaerok/backend/user/controller/UserController.java
@@ -1,0 +1,48 @@
+package com.chaerok.backend.user.controller;
+
+import com.chaerok.backend.auth.security.AuthenticatedUser;
+import com.chaerok.backend.user.dto.UpdateNicknameRequest;
+import com.chaerok.backend.user.dto.UserResponse;
+import com.chaerok.backend.user.entity.User;
+import com.chaerok.backend.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> getMyInfo(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        User user = userService.findById(
+                authenticatedUser.userId()
+        );
+
+        return ResponseEntity.ok(
+                UserResponse.from(user)
+        );
+    }
+
+    @PatchMapping("/me/nickname")
+    public ResponseEntity<UserResponse> updateNickname(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @Valid @RequestBody UpdateNicknameRequest request
+    ) {
+        User user = userService.updateNickname(
+                authenticatedUser.userId(),
+                request.nickname()
+        );
+
+        return ResponseEntity.ok(
+                UserResponse.from(user)
+        );
+    }
+}

--- a/src/main/java/com/chaerok/backend/user/dto/UpdateNicknameRequest.java
+++ b/src/main/java/com/chaerok/backend/user/dto/UpdateNicknameRequest.java
@@ -1,0 +1,12 @@
+package com.chaerok.backend.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateNicknameRequest(
+
+        @NotBlank
+        @Size(max = 30)
+        String nickname
+) {
+}

--- a/src/main/java/com/chaerok/backend/user/dto/UserResponse.java
+++ b/src/main/java/com/chaerok/backend/user/dto/UserResponse.java
@@ -1,0 +1,24 @@
+package com.chaerok.backend.user.dto;
+
+import com.chaerok.backend.user.entity.OAuthProvider;
+import com.chaerok.backend.user.entity.User;
+import com.chaerok.backend.user.entity.UserRole;
+
+public record UserResponse(
+        Long id,
+        OAuthProvider provider,
+        String nickname,
+        String email,
+        UserRole role
+) {
+
+    public static UserResponse from(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getProvider(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getRole()
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,20 @@ external:
     key: ${TOUR_API_KEY}
   odii:
     key: ${ODII_API_KEY}
+
+oauth:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    issuer: https://kauth.kakao.com
+    jwk-set-uri: https://kauth.kakao.com/.well-known/jwks.json
+
+  google:
+    client-id: ${GOOGLE_CLIENT_ID}
+    issuer: https://accounts.google.com
+    jwk-set-uri: https://www.googleapis.com/oauth2/v3/certs
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-expiration: ${JWT_ACCESS_EXPIRATION}
+  refresh-expiration: ${JWT_REFRESH_EXPIRATION}
+  signup-expiration: ${JWT_SIGNUP_EXPIRATION}

--- a/src/test/java/com/chaerok/backend/auth/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/chaerok/backend/auth/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,115 @@
+package com.chaerok.backend.auth.jwt;
+
+import com.chaerok.backend.global.exception.InvalidTokenException;
+import com.chaerok.backend.user.entity.OAuthProvider;
+import com.chaerok.backend.user.entity.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        String secret =
+                "chaerok-test-secret-key-must-be-longer-than-32-bytes";
+
+        jwtTokenProvider = new JwtTokenProvider(
+                secret,
+                1_800_000L,
+                1_209_600_000L,
+                600_000L
+        );
+    }
+
+    @Test
+    void 액세스_토큰을_생성하고_정보를_조회한다() {
+        // given
+        Long userId = 1L;
+        UserRole role = UserRole.USER;
+
+        // when
+        String accessToken =
+                jwtTokenProvider.createAccessToken(userId, role);
+
+        Jwt jwt = jwtTokenProvider.parseToken(accessToken);
+
+        // then
+        assertThat(jwt.getSubject()).isEqualTo("1");
+        assertThat(jwt.getClaimAsString("type"))
+                .isEqualTo(TokenType.ACCESS.name());
+        assertThat(jwt.getClaimAsString("role"))
+                .isEqualTo(UserRole.USER.name());
+
+        assertThat(jwtTokenProvider.getUserId(accessToken))
+                .isEqualTo(userId);
+        assertThat(jwtTokenProvider.getRole(accessToken))
+                .isEqualTo(role);
+        assertThat(jwtTokenProvider.isAccessToken(accessToken))
+                .isTrue();
+        assertThat(jwtTokenProvider.isRefreshToken(accessToken))
+                .isFalse();
+    }
+
+    @Test
+    void 리프레시_토큰을_생성하고_정보를_조회한다() {
+        // given
+        Long userId = 1L;
+
+        // when
+        String refreshToken =
+                jwtTokenProvider.createRefreshToken(userId);
+
+        // then
+        assertThat(jwtTokenProvider.getUserId(refreshToken))
+                .isEqualTo(userId);
+        assertThat(jwtTokenProvider.isRefreshToken(refreshToken))
+                .isTrue();
+        assertThat(jwtTokenProvider.isAccessToken(refreshToken))
+                .isFalse();
+    }
+
+    @Test
+    void 회원가입_토큰에서_사용자_정보를_조회한다() {
+        // given
+        String signupToken = jwtTokenProvider.createSignupToken(
+                OAuthProvider.KAKAO,
+                "kakao-user-1",
+                "채록 사용자",
+                "test@example.com"
+        );
+
+        // when
+        SignupTokenInfo tokenInfo =
+                jwtTokenProvider.getSignupTokenInfo(signupToken);
+
+        // then
+        assertThat(tokenInfo.provider())
+                .isEqualTo(OAuthProvider.KAKAO);
+        assertThat(tokenInfo.providerUserId())
+                .isEqualTo("kakao-user-1");
+        assertThat(tokenInfo.email())
+                .isEqualTo("test@example.com");
+        assertThat(jwtTokenProvider.isSignupToken(signupToken))
+                .isTrue();
+    }
+
+    @Test
+    void 액세스_토큰은_회원가입_토큰으로_사용할_수_없다() {
+        // given
+        String accessToken = jwtTokenProvider.createAccessToken(
+                1L,
+                UserRole.USER
+        );
+
+        // when & then
+        assertThatThrownBy(
+                () -> jwtTokenProvider.getSignupTokenInfo(accessToken)
+        ).isInstanceOf(InvalidTokenException.class);
+    }
+}

--- a/src/test/java/com/chaerok/backend/auth/jwt/TokenHashUtilTest.java
+++ b/src/test/java/com/chaerok/backend/auth/jwt/TokenHashUtilTest.java
@@ -1,0 +1,26 @@
+package com.chaerok.backend.auth.jwt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TokenHashUtilTest {
+
+    private final TokenHashUtil tokenHashUtil =
+            new TokenHashUtil();
+
+    @Test
+    void 같은_토큰은_같은_해시값을_생성한다() {
+        // given
+        String token = "refresh-token";
+
+        // when
+        String firstHash = tokenHashUtil.hash(token);
+        String secondHash = tokenHashUtil.hash(token);
+
+        // then
+        assertThat(firstHash).isEqualTo(secondHash);
+        assertThat(firstHash).hasSize(64);
+        assertThat(firstHash).isNotEqualTo(token);
+    }
+}


### PR DESCRIPTION
## ✨ 변경 사항

- 카카오 OIDC ID Token 검증 구현
- 구글 ID Token 검증 구현
- OAuth 로그인 및 신규 사용자 회원가입 흐름 구현
- Access Token, Refresh Token, Signup Token 발급 구현
- Refresh Token DB 저장 및 SHA-256 해시 처리
- Refresh Token Rotation 및 로그아웃 구현
- JWT 인증 필터와 인증 실패 응답 처리
- USER / ADMIN 권한 처리
- 내 정보 조회 및 닉네임 수정 API 구현
- Swagger Bearer 인증 설정
- 인증 관련 예외 처리 및 테스트 추가

## 📌 담당 영역

- [x] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [x] DB / Supabase
- [x] 문서 / 기타

## 🔗 관련 이슈

- Closes #2 

## 🧩 API / DB 변경 사항

### API 추가
- `POST /api/auth/login`
- `POST /api/auth/signup`
- `POST /api/auth/refresh`
- `POST /api/auth/logout`
- `GET /api/users/me`
- `PATCH /api/users/me/nickname`

### DB 변경
- `refresh_tokens` 테이블 추가
- Refresh Token 원문 대신 SHA-256 해시값 저장
- 사용자 권한 `USER`, `ADMIN` 적용

## ✅ 테스트

- [x] 서버 실행 확인
- [x] Swagger 확인
- [x] 수동 테스트 완료
- [x] DB 저장/조회 확인
- [x] JWT 및 토큰 해시 단위 테스트 통과

## 💬 참고 사항

- 카카오는 OIDC ID Token, 구글은 ID Token 방식으로 검증
- 일반 아이디·비밀번호 로그인은 구현하지 않음
- Access Token은 DB에 저장하지 않음
- Refresh Token은 재발급 시 기존 토큰을 폐기하고 새 토큰으로 교체
- 로그아웃 후에도 기존 Access Token은 만료 전까지 유효하며, 별도 블랙리스트는 적용하지 않음