### PR TITLE
feat(auth): 회원가입 약관 동의 기록 추가

### DIFF
--- a/src/main/java/com/chaerok/backend/auth/constant/TermsVersion.java
+++ b/src/main/java/com/chaerok/backend/auth/constant/TermsVersion.java
@@ -1,0 +1,10 @@
+package com.chaerok.backend.auth.constant;
+
+public final class TermsVersion {
+
+    public static final String SERVICE_TERMS = "1.0";
+    public static final String PRIVACY_POLICY = "1.0";
+
+    private TermsVersion() {
+    }
+}

--- a/src/main/java/com/chaerok/backend/auth/dto/SignupRequest.java
+++ b/src/main/java/com/chaerok/backend/auth/dto/SignupRequest.java
@@ -1,5 +1,6 @@
 package com.chaerok.backend.auth.dto;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -13,6 +14,12 @@ public record SignupRequest(
                 max = 30,
                 message = "닉네임은 30자 이하여야 합니다."
         )
-        String nickname
+        String nickname,
+
+        @AssertTrue(message = "서비스 이용약관에 동의해야 합니다.")
+        boolean termsAgreed,
+
+        @AssertTrue(message = "개인정보 수집 및 이용에 동의해야 합니다.")
+        boolean privacyAgreed
 ) {
 }

--- a/src/main/java/com/chaerok/backend/auth/service/AuthService.java
+++ b/src/main/java/com/chaerok/backend/auth/service/AuthService.java
@@ -11,6 +11,7 @@ import com.chaerok.backend.global.exception.DuplicateUserException;
 import com.chaerok.backend.global.exception.InvalidTokenException;
 import com.chaerok.backend.user.entity.User;
 import com.chaerok.backend.user.service.UserService;
+import com.chaerok.backend.auth.constant.TermsVersion;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -102,7 +103,9 @@ public class AuthService {
                 tokenInfo.provider(),
                 tokenInfo.providerUserId(),
                 request.nickname(),
-                tokenInfo.email()
+                tokenInfo.email(),
+                TermsVersion.SERVICE_TERMS,
+                TermsVersion.PRIVACY_POLICY
         );
 
         String accessToken =

--- a/src/main/java/com/chaerok/backend/user/entity/User.java
+++ b/src/main/java/com/chaerok/backend/user/entity/User.java
@@ -47,26 +47,55 @@ public class User {
     @Column(nullable = false, length = 20)
     private UserRole role;
 
+    @Column(name = "terms_agreed_at", nullable = false, updatable = false)
+    private LocalDateTime termsAgreedAt;
+
+    @Column(name = "privacy_agreed_at", nullable = false, updatable = false)
+    private LocalDateTime privacyAgreedAt;
+
+    @Column(name = "terms_version", nullable = false, length = 20, updatable = false)
+    private String termsVersion;
+
+    @Column(name = "privacy_version", nullable = false, length = 20, updatable = false)
+    private String privacyVersion;
+
     private User(
             OAuthProvider provider,
             String providerUserId,
             String nickname,
-            String email
+            String email,
+            String termsVersion,
+            String privacyVersion
     ) {
+        LocalDateTime agreedAt = LocalDateTime.now();
+
         this.provider = provider;
         this.providerUserId = providerUserId;
         this.nickname = nickname;
         this.email = email;
         this.role = UserRole.USER;
+        this.termsAgreedAt = agreedAt;
+        this.privacyAgreedAt = agreedAt;
+        this.termsVersion = termsVersion;
+        this.privacyVersion = privacyVersion;
     }
 
     public static User create(
             OAuthProvider provider,
             String providerUserId,
             String nickname,
-            String email
+            String email,
+            String termsVersion,
+            String privacyVersion
     ) {
-        return new User(provider, providerUserId, nickname, email);
+        return new User(
+                provider,
+                providerUserId,
+                nickname,
+                email,
+                termsVersion,
+                privacyVersion
+        );
     }
 
     public void updateNickname(String nickname) {

--- a/src/main/java/com/chaerok/backend/user/service/UserService.java
+++ b/src/main/java/com/chaerok/backend/user/service/UserService.java
@@ -37,7 +37,9 @@ public class UserService {
             OAuthProvider provider,
             String providerUserId,
             String nickname,
-            String email
+            String email,
+            String termsVersion,
+            String privacyVersion
     ) {
         if (userRepository.existsByProviderAndProviderUserId(
                 provider,
@@ -50,7 +52,9 @@ public class UserService {
                 provider,
                 providerUserId,
                 nickname,
-                email
+                email,
+                termsVersion,
+                privacyVersion
         );
 
         return userRepository.save(user);


### PR DESCRIPTION
## ✨ 변경 사항

* 회원가입 요청에 서비스 이용약관 및 개인정보 수집·이용 동의 필드 추가
* 필수 약관 미동의 시 회원가입 요청 검증 실패 처리
* 회원가입 시 약관 동의 시각과 적용 버전 저장
* 약관 버전을 백엔드 상수로 관리하도록 구현

## 📌 담당 영역

* [ ] 공통 설정 / 인프라
* [x] Backend 1: 사용자·관광 데이터·코스/Odii
* [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
* [x] DB / Supabase
* [ ] 문서 / 기타

## 🔗 관련 이슈

* Closes #6

## 🧩 API / DB 변경 사항

### API 변경

* `POST /api/auth/signup`
* 요청 필드 추가

  * `termsAgreed`
  * `privacyAgreed`
* 필수 약관 미동의 시 `400 Bad Request` 응답

### DB 변경

`users` 테이블에 다음 컬럼 추가

* `terms_agreed_at`
* `privacy_agreed_at`
* `terms_version`
* `privacy_version`

## ✅ 테스트

* [x] 서버 실행 확인
* [x] Swagger 확인
* [x] 수동 테스트 완료
* [ ] 해당 없음

## 💬 참고 사항

* 약관 버전은 프론트에서 전달받지 않고 백엔드 상수로 관리
* 약관 본문 전체가 아닌 동의 시각과 버전만 저장
* 초기 약관 버전은 서비스 이용약관과 개인정보 수집·이용 모두 `1.0`으로 설정
