### PR TITLE
feat(user): 회원 탈퇴 및 OAuth 연결 해제 구현

### DIFF
--- a/src/main/java/com/chaerok/backend/auth/oauth/unlink/KakaoOAuthUnlinkService.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/unlink/KakaoOAuthUnlinkService.java
@@ -1,0 +1,64 @@
+package com.chaerok.backend.auth.oauth.unlink;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Slf4j
+@Service
+public class KakaoOAuthUnlinkService {
+
+    private static final String KAKAO_UNLINK_URL =
+            "https://kapi.kakao.com/v1/user/unlink";
+
+    private final RestClient restClient;
+    private final String adminKey;
+
+    public KakaoOAuthUnlinkService(
+            RestClient.Builder restClientBuilder,
+            @Value("${oauth.kakao.admin-key}") String adminKey
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.adminKey = adminKey;
+    }
+
+    public void unlink(String providerUserId) {
+        MultiValueMap<String, String> requestBody =
+                new LinkedMultiValueMap<>();
+
+        requestBody.add("target_id_type", "user_id");
+        requestBody.add("target_id", providerUserId);
+
+        try {
+            restClient.post()
+                    .uri(KAKAO_UNLINK_URL)
+                    .header(
+                            "Authorization",
+                            "KakaoAK " + adminKey
+                    )
+                    .contentType(
+                            MediaType.APPLICATION_FORM_URLENCODED
+                    )
+                    .body(requestBody)
+                    .retrieve()
+                    .toBodilessEntity();
+
+            log.info(
+                    "카카오 연결 해제 성공: providerUserId={}",
+                    providerUserId
+            );
+        } catch (RestClientException exception) {
+            // 연결 해제가 실패해도 채록 회원 탈퇴는 계속 진행
+            log.warn(
+                    "카카오 연결 해제 실패: providerUserId={}",
+                    providerUserId,
+                    exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/chaerok/backend/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/chaerok/backend/auth/repository/RefreshTokenRepository.java
@@ -11,4 +11,6 @@ public interface RefreshTokenRepository
     Optional<RefreshToken> findByTokenHash(String tokenHash);
 
     void deleteByTokenHash(String tokenHash);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/chaerok/backend/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/chaerok/backend/auth/service/RefreshTokenService.java
@@ -62,4 +62,9 @@ public class RefreshTokenService {
 
         refreshTokenRepository.deleteByTokenHash(tokenHash);
     }
+
+    @Transactional
+    public void deleteAllByUserId(Long userId) {
+        refreshTokenRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/chaerok/backend/user/controller/UserController.java
+++ b/src/main/java/com/chaerok/backend/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.chaerok.backend.user.dto.UpdateNicknameRequest;
 import com.chaerok.backend.user.dto.UserResponse;
 import com.chaerok.backend.user.entity.User;
 import com.chaerok.backend.user.service.UserService;
+import com.chaerok.backend.user.service.UserWithdrawalService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final UserWithdrawalService userWithdrawalService;
 
     @GetMapping("/me")
     public ResponseEntity<UserResponse> getMyInfo(
@@ -44,5 +46,16 @@ public class UserController {
         return ResponseEntity.ok(
                 UserResponse.from(user)
         );
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> withdraw(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        userWithdrawalService.withdraw(
+                authenticatedUser.userId()
+        );
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/chaerok/backend/user/service/UserService.java
+++ b/src/main/java/com/chaerok/backend/user/service/UserService.java
@@ -67,4 +67,10 @@ public class UserService {
 
         return user;
     }
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = findById(userId);
+        userRepository.delete(user);
+    }
 }

--- a/src/main/java/com/chaerok/backend/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/chaerok/backend/user/service/UserWithdrawalService.java
@@ -1,0 +1,33 @@
+package com.chaerok.backend.user.service;
+
+import com.chaerok.backend.auth.oauth.unlink.KakaoOAuthUnlinkService;
+import com.chaerok.backend.auth.service.RefreshTokenService;
+import com.chaerok.backend.user.entity.OAuthProvider;
+import com.chaerok.backend.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserWithdrawalService {
+
+    private final UserService userService;
+    private final RefreshTokenService refreshTokenService;
+    private final KakaoOAuthUnlinkService kakaoOAuthUnlinkService;
+
+    @Transactional
+    public void withdraw(Long userId) {
+        User user = userService.findById(userId);
+
+        if (user.getProvider() == OAuthProvider.KAKAO) {
+            kakaoOAuthUnlinkService.unlink(
+                    user.getProviderUserId()
+            );
+        }
+
+        refreshTokenService.deleteAllByUserId(user.getId());
+
+        userService.deleteUser(user.getId());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,7 @@ external:
 oauth:
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
+    admin-key: ${KAKAO_ADMIN_KEY}
     issuer: https://kauth.kakao.com
     jwk-set-uri: https://kauth.kakao.com/.well-known/jwks.json
 

--- a/src/test/java/com/chaerok/backend/user/service/UserWithdrawalServiceTest.java
+++ b/src/test/java/com/chaerok/backend/user/service/UserWithdrawalServiceTest.java
@@ -1,0 +1,94 @@
+package com.chaerok.backend.user.service;
+
+import com.chaerok.backend.auth.oauth.unlink.KakaoOAuthUnlinkService;
+import com.chaerok.backend.auth.service.RefreshTokenService;
+import com.chaerok.backend.user.entity.OAuthProvider;
+import com.chaerok.backend.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserWithdrawalServiceTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private KakaoOAuthUnlinkService kakaoOAuthUnlinkService;
+
+    @Mock
+    private User user;
+
+    private UserWithdrawalService userWithdrawalService;
+
+    @BeforeEach
+    void setUp() {
+        userWithdrawalService = new UserWithdrawalService(
+                userService,
+                refreshTokenService,
+                kakaoOAuthUnlinkService
+        );
+    }
+
+    @Test
+    void 카카오_사용자_탈퇴_시_연결을_해제하고_토큰과_사용자를_삭제한다() {
+        // given
+        Long userId = 1L;
+        String providerUserId = "123456789";
+
+        when(userService.findById(userId)).thenReturn(user);
+        when(user.getId()).thenReturn(userId);
+        when(user.getProvider()).thenReturn(OAuthProvider.KAKAO);
+        when(user.getProviderUserId()).thenReturn(providerUserId);
+
+        // when
+        userWithdrawalService.withdraw(userId);
+
+        // then
+        InOrder inOrder = inOrder(
+                userService,
+                kakaoOAuthUnlinkService,
+                refreshTokenService
+        );
+
+        inOrder.verify(userService).findById(userId);
+        inOrder.verify(kakaoOAuthUnlinkService)
+                .unlink(providerUserId);
+        inOrder.verify(refreshTokenService)
+                .deleteAllByUserId(userId);
+        inOrder.verify(userService)
+                .deleteUser(userId);
+    }
+
+    @Test
+    void 구글_사용자_탈퇴_시_카카오_연결_해제_없이_토큰과_사용자를_삭제한다() {
+        // given
+        Long userId = 2L;
+
+        when(userService.findById(userId)).thenReturn(user);
+        when(user.getId()).thenReturn(userId);
+        when(user.getProvider()).thenReturn(OAuthProvider.GOOGLE);
+
+        // when
+        userWithdrawalService.withdraw(userId);
+
+        // then
+        verify(kakaoOAuthUnlinkService, never())
+                .unlink(anyString());
+
+        verify(refreshTokenService)
+                .deleteAllByUserId(userId);
+
+        verify(userService)
+                .deleteUser(userId);
+    }
+}


### PR DESCRIPTION
## ✨ 변경 사항

* `DELETE /api/users/me` 회원 탈퇴 API 구현
* Access Token을 기준으로 현재 사용자 식별
* 탈퇴 사용자의 Refresh Token 전체 삭제 기능 추가
* 사용자 데이터 물리 삭제 처리
* 카카오 사용자 탈퇴 시 카카오 연결 해제 API 호출
* OAuth 제공자에 따른 연결 해제 처리 분기
* OAuth 연결 해제 실패 시 로그를 남기고 채록 계정 삭제는 계속 진행
* 회원 탈퇴 전체 흐름을 조율하는 `UserWithdrawalService` 구현
* 회원 탈퇴 서비스 단위 테스트 추가

## 📌 담당 영역

* [ ] 공통 설정 / 인프라
* [x] Backend 1: 사용자·관광 데이터·코스/Odii
* [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
* [ ] DB / Supabase
* [x] 외부 API 연동
* [x] Swagger / 문서
* [ ] 기타

## 🔗 관련 이슈

* closes #10 

## 🧩 API / DB 변경 사항

### API 추가

* `DELETE /api/users/me`
* Access Token 인증 필요
* 성공 시 `204 No Content`

### 외부 API 연동

* 카카오 사용자 탈퇴 시 카카오 연결 해제 API 호출
* 구글 연결 해제는 Flutter에서 처리한 후 백엔드 탈퇴 API를 호출하는 구조
* 카카오 연결 해제에 필요한 `KAKAO_ADMIN_KEY` 환경 변수 추가

### DB 변경

* 신규 테이블 및 컬럼 추가 없음
* 탈퇴 사용자의 `refresh_tokens` 데이터 전체 삭제
* 탈퇴 사용자의 `users` 데이터 물리 삭제

## ✅ 테스트

* [x] 서버 실행 확인
* [x] Swagger 확인
* [ ] 수동 테스트 완료
* [ ] 해당 없음

* `UserWithdrawalServiceTest` 테스트 2건 통과

  * 카카오 사용자 탈퇴 시 카카오 연결 해제 호출 확인
  * 구글 사용자 탈퇴 시 카카오 연결 해제 미호출 확인
  * Refresh Token 전체 삭제 호출 확인
  * 사용자 물리 삭제 호출 확인

* 실제 OAuth 로그인부터 회원 탈퇴 및 재가입까지의 통합 테스트는 Flutter 로그인 연동 후 진행 예정

## 💬 참고 사항

* 탈퇴 후 기존 여행 기록과 결과물은 복구하지 않음
* 구글 사용자는 Flutter에서 Google 연결 해제를 먼저 시도한 뒤 백엔드 탈퇴 API 호출
* OAuth 연결 해제 실패가 채록 내부 회원 탈퇴를 막지 않도록 처리
* 향후 필름 롤, 방문 기록, 사진, 릴스, 엽서 및 Supabase Storage 결과물이 추가되면 각 도메인 삭제 서비스를 `UserWithdrawalService`에 연결할 예정
