### PR TITLE
docs(swagger): API 그룹 및 설명 통일

### DIFF
--- a/src/main/java/com/chaerok/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/chaerok/backend/auth/controller/AuthController.java
@@ -2,11 +2,14 @@ package com.chaerok.backend.auth.controller;
 
 import com.chaerok.backend.auth.dto.*;
 import com.chaerok.backend.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Auth", description = "인증 API")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -14,6 +17,10 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @Operation(
+            summary = "OAuth 로그인",
+            description = "카카오 또는 구글 ID Token을 검증합니다. 기존 회원은 Access Token과 Refresh Token을 발급하고, 신규 회원은 회원가입에 사용할 Signup Token을 반환합니다."
+    )
     @PostMapping("/login")
     public ResponseEntity<OAuthLoginResponse> login(
             @Valid @RequestBody OAuthLoginRequest request
@@ -23,6 +30,10 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "회원가입",
+            description = "Signup Token과 약관 동의 정보를 검증한 뒤 신규 사용자를 생성하고 Access Token과 Refresh Token을 발급합니다."
+    )
     @PostMapping("/signup")
     public ResponseEntity<TokenResponse> signup(
             @Valid @RequestBody SignupRequest request
@@ -32,6 +43,10 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "토큰 갱신",
+            description = "유효한 Refresh Token을 검증하고 새로운 Access Token과 Refresh Token을 발급합니다."
+    )
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(
             @Valid @RequestBody RefreshTokenRequest request
@@ -41,6 +56,10 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "로그아웃",
+            description = "전달받은 Refresh Token을 폐기해 로그아웃 처리합니다."
+    )
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(
             @Valid @RequestBody RefreshTokenRequest request

--- a/src/main/java/com/chaerok/backend/global/controller/HealthCheckController.java
+++ b/src/main/java/com/chaerok/backend/global/controller/HealthCheckController.java
@@ -1,11 +1,18 @@
 package com.chaerok.backend.global.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Health", description = "서버 상태 확인 API")
 @RestController
 public class HealthCheckController {
 
+    @Operation(
+            summary = "서버 상태 확인",
+            description = "채록 백엔드 서버가 정상적으로 실행 중인지 확인합니다."
+    )
     @GetMapping("/api/health")
     public String healthCheck() {
         return "채록 백엔드 서버가 정상 실행 중입니다.";

--- a/src/main/java/com/chaerok/backend/region/controller/RegionController.java
+++ b/src/main/java/com/chaerok/backend/region/controller/RegionController.java
@@ -12,8 +12,8 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Region", description = "지역 검증 API")
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/api/regions")
+@RequiredArgsConstructor
 public class RegionController {
 
     private final RegionService regionService;
@@ -27,6 +27,7 @@ public class RegionController {
             @Valid @RequestBody ResolveRegionRequest request
     ) {
         RegionResponse response = regionService.resolve(request);
+
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/chaerok/backend/user/controller/UserController.java
+++ b/src/main/java/com/chaerok/backend/user/controller/UserController.java
@@ -6,12 +6,15 @@ import com.chaerok.backend.user.dto.UserResponse;
 import com.chaerok.backend.user.entity.User;
 import com.chaerok.backend.user.service.UserService;
 import com.chaerok.backend.user.service.UserWithdrawalService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "User", description = "사용자 API")
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
@@ -20,6 +23,10 @@ public class UserController {
     private final UserService userService;
     private final UserWithdrawalService userWithdrawalService;
 
+    @Operation(
+            summary = "내 정보 조회",
+            description = "인증된 사용자의 기본 정보를 조회합니다."
+    )
     @GetMapping("/me")
     public ResponseEntity<UserResponse> getMyInfo(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser
@@ -27,12 +34,15 @@ public class UserController {
         User user = userService.findById(
                 authenticatedUser.userId()
         );
+        UserResponse response = UserResponse.from(user);
 
-        return ResponseEntity.ok(
-                UserResponse.from(user)
-        );
+        return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "닉네임 수정",
+            description = "인증된 사용자의 닉네임을 수정하고 변경된 사용자 정보를 반환합니다."
+    )
     @PatchMapping("/me/nickname")
     public ResponseEntity<UserResponse> updateNickname(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
@@ -42,12 +52,15 @@ public class UserController {
                 authenticatedUser.userId(),
                 request.nickname()
         );
+        UserResponse response = UserResponse.from(user);
 
-        return ResponseEntity.ok(
-                UserResponse.from(user)
-        );
+        return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "인증된 사용자의 계정과 인증 관련 데이터를 삭제합니다."
+    )
     @DeleteMapping("/me")
     public ResponseEntity<Void> withdraw(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser


### PR DESCRIPTION
## ✨ 변경 사항

* Auth, User, Region, Health 컨트롤러의 Swagger 그룹명 통일
* 각 API의 목적과 동작을 설명하는 `@Operation` 추가
* 컨트롤러 응답 타입 및 반환 형식 정리
* Swagger API 문서 가독성 개선

## 📌 담당 영역

* [ ] 공통 설정 / 인프라
* [x] Backend 1: 사용자·관광 데이터·코스/Odii
* [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
* [ ] DB / Supabase
* [x] 문서 / 기타

## 🔗 관련 이슈

* closes #16 

## 🧩 API / DB 변경 사항

* API 경로 및 요청·응답 구조 변경 없음
* DB 변경 없음
* Swagger 그룹명 및 API 설명 추가
* `ResponseEntity` 반환 타입 명시 및 컨트롤러 반환 형식 정리

## ✅ 테스트

* [x] 서버 실행 확인
* [x] Swagger 확인
* [x] 수동 테스트 완료
* [ ] 해당 없음

## 💬 참고 사항

* Swagger 그룹명을 `Auth`, `User`, `Region`, `Health`로 통일
* 기존 API 비즈니스 로직과 보안 설정 변경 없음
