### PR TITLE
chore(config): 카카오 키 환경변수 명칭 구분

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,7 @@ supabase:
 
 external:
   kakao:
-    api-key: ${KAKAO_API_KEY}
+    api-key: ${KAKAO_REST_API_KEY}
   tour-api:
     key: ${TOUR_API_KEY}
   odii:
@@ -43,7 +43,7 @@ external:
 
 oauth:
   kakao:
-    client-id: ${KAKAO_CLIENT_ID}
+    client-id: ${KAKAO_NATIVE_APP_KEY}
     admin-key: ${KAKAO_ADMIN_KEY}
     issuer: https://kauth.kakao.com
     jwk-set-uri: https://kauth.kakao.com/.well-known/jwks.json


### PR DESCRIPTION
## ✨ 변경 사항

- 카카오 REST API 키와 Native app key의 환경변수 명칭 구분
- `KAKAO_API_KEY`를 `KAKAO_REST_API_KEY`로 변경
- `KAKAO_CLIENT_ID`를 `KAKAO_NATIVE_APP_KEY`로 변경

## 📌 담당 영역

- [x] 공통 설정 / 인프라
- [ ] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 외부 API 연동
- [ ] Swagger / 문서
- [ ] 기타

## 🔗 관련 이슈

- 없음

## 🧩 API / DB 변경 사항

- API 변경 없음
- DB 변경 없음
- 환경변수 명칭 변경
  - `KAKAO_REST_API_KEY`
  - `KAKAO_NATIVE_APP_KEY`
  - `KAKAO_ADMIN_KEY` 유지

## ✅ 테스트

- [x] 서버 실행 확인
- [ ] Swagger 확인
- [ ] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- 로컬 `.env`와 Render 환경변수도 동일한 이름으로 변경 필요