### PR TITLE
fix(auth): 로그인 시 read-only 트랜잭션 오류 수정

### DIFF
--- a/src/main/java/com/chaerok/backend/auth/service/AuthService.java
+++ b/src/main/java/com/chaerok/backend/auth/service/AuthService.java
@@ -28,6 +28,7 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
 
+    @Transactional
     public OAuthLoginResponse login(OAuthLoginRequest request) {
         OAuthTokenVerifier verifier =
                 verifierResolver.resolve(request.provider());


### PR DESCRIPTION
## ✨ 변경 사항

- 기존 사용자 재로그인 시 Refresh Token 저장 과정에서 발생하던 read-only 트랜잭션 오류 수정
- `AuthService.login()`에 쓰기 트랜잭션 적용
- 기존 사용자 로그인 시 Refresh Token INSERT가 정상 처리되도록 수정

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [x] DB / Supabase
- [ ] 외부 API 연동
- [ ] Swagger / 문서
- [ ] 기타

## 🔗 관련 이슈

- closes #23 

## 🧩 API / DB 변경 사항

- API 변경 없음
- DB 구조 변경 없음
- 로그인 시 Refresh Token 저장 트랜잭션 설정 수정

## ✅ 테스트

- [x] 서버 실행 확인
- [ ] Swagger 확인
- [ ] 수동 테스트 완료
- [ ] 해당 없음

- 전체 테스트 통과
- 기존 사용자 재로그인 수동 확인 필요

## 💬 참고 사항

- 원인은 `AuthService` 클래스에 `@Transactional(readOnly = true)`가 적용된 상태에서 `login()` 메서드가 Refresh Token 저장을 시도한 것
- `signup()`, `refresh()`, `logout()`은 이미 쓰기 트랜잭션이 적용되어 있어 이번 수정 범위에서 제외
- 에러 응답 메시지 상세화는 전역 예외 응답 구조와 함께 별도 작업으로 분리 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 로그인 과정이 쓰기 작업을 포함한 별도 트랜잭션에서 처리되도록 개선되어, 리프레시 토큰 저장이 더 안정적으로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->