### PR TITLE
refactor(global): API 예외 응답 포맷 개선

### DIFF
--- a/src/main/java/com/chaerok/backend/auth/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/chaerok/backend/auth/security/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,6 @@
 package com.chaerok.backend.auth.security;
 
+import com.chaerok.backend.global.exception.ErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,12 +12,10 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
-public class JwtAuthenticationEntryPoint
-        implements AuthenticationEntryPoint {
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private final ObjectMapper objectMapper;
 
@@ -26,17 +25,19 @@ public class JwtAuthenticationEntryPoint
             HttpServletResponse response,
             AuthenticationException authException
     ) throws IOException, ServletException {
-
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
 
+        ErrorResponse errorResponse = ErrorResponse.of(
+                "UNAUTHORIZED",
+                "인증이 필요합니다.",
+                request.getRequestURI()
+        );
+
         objectMapper.writeValue(
                 response.getWriter(),
-                Map.of(
-                        "code", "UNAUTHORIZED",
-                        "message", "인증이 필요합니다."
-                )
+                errorResponse
         );
     }
 }

--- a/src/main/java/com/chaerok/backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/chaerok/backend/global/exception/ErrorResponse.java
@@ -1,7 +1,48 @@
 package com.chaerok.backend.global.exception;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public record ErrorResponse(
         String code,
-        String message
+        String message,
+        String path,
+        LocalDateTime timestamp,
+        List<FieldErrorDetail> errors
 ) {
+
+    public static ErrorResponse of(
+            String code,
+            String message,
+            String path
+    ) {
+        return new ErrorResponse(
+                code,
+                message,
+                path,
+                LocalDateTime.now(),
+                List.of()
+        );
+    }
+
+    public static ErrorResponse of(
+            String code,
+            String message,
+            String path,
+            List<FieldErrorDetail> errors
+    ) {
+        return new ErrorResponse(
+                code,
+                message,
+                path,
+                LocalDateTime.now(),
+                errors
+        );
+    }
+
+    public record FieldErrorDetail(
+            String field,
+            String message
+    ) {
+    }
 }

--- a/src/main/java/com/chaerok/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chaerok/backend/global/exception/GlobalExceptionHandler.java
@@ -1,78 +1,123 @@
 package com.chaerok.backend.global.exception;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.List;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(InvalidTokenException.class)
     public ResponseEntity<ErrorResponse> handleInvalidToken(
-            InvalidTokenException exception
+            InvalidTokenException exception,
+            HttpServletRequest request
     ) {
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
-                .body(new ErrorResponse(
+                .body(ErrorResponse.of(
                         "INVALID_TOKEN",
-                        exception.getMessage()
+                        exception.getMessage(),
+                        request.getRequestURI()
                 ));
     }
 
     @ExceptionHandler(DuplicateUserException.class)
     public ResponseEntity<ErrorResponse> handleDuplicateUser(
-            DuplicateUserException exception
+            DuplicateUserException exception,
+            HttpServletRequest request
     ) {
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
-                .body(new ErrorResponse(
+                .body(ErrorResponse.of(
                         "DUPLICATE_USER",
-                        exception.getMessage()
+                        exception.getMessage(),
+                        request.getRequestURI()
                 ));
     }
 
     @ExceptionHandler(PlaceNotFoundException.class)
     public ResponseEntity<ErrorResponse> handlePlaceNotFound(
-            PlaceNotFoundException exception
+            PlaceNotFoundException exception,
+            HttpServletRequest request
     ) {
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse(
+                .body(ErrorResponse.of(
                         "PLACE_NOT_FOUND",
-                        exception.getMessage()
+                        exception.getMessage(),
+                        request.getRequestURI()
                 ));
     }
 
     @ExceptionHandler(RegionNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleRegionNotFound(
-            RegionNotFoundException exception
+            RegionNotFoundException exception,
+            HttpServletRequest request
     ) {
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse(
+                .body(ErrorResponse.of(
                         "REGION_NOT_FOUND",
-                        exception.getMessage()
+                        exception.getMessage(),
+                        request.getRequestURI()
                 ));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidation(
-            MethodArgumentNotValidException exception
+            MethodArgumentNotValidException exception,
+            HttpServletRequest request
     ) {
-        String message = exception.getBindingResult()
-                .getFieldErrors()
-                .stream()
-                .findFirst()
-                .map(error -> error.getDefaultMessage())
-                .orElse("요청값이 올바르지 않습니다.");
+        List<ErrorResponse.FieldErrorDetail> errors =
+                exception.getBindingResult()
+                        .getFieldErrors()
+                        .stream()
+                        .map(error -> new ErrorResponse.FieldErrorDetail(
+                                error.getField(),
+                                error.getDefaultMessage()
+                        ))
+                        .toList();
 
         return ResponseEntity
                 .badRequest()
-                .body(new ErrorResponse(
+                .body(ErrorResponse.of(
                         "INVALID_REQUEST",
-                        message
+                        "요청값이 올바르지 않습니다.",
+                        request.getRequestURI(),
+                        errors
+                ));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(
+            IllegalArgumentException exception,
+            HttpServletRequest request
+    ) {
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(
+                        "BAD_REQUEST",
+                        exception.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(
+                        "INTERNAL_SERVER_ERROR",
+                        "서버 내부 오류가 발생했습니다.",
+                        request.getRequestURI()
                 ));
     }
 }


### PR DESCRIPTION
## ✨ 변경 사항

- 공통 에러 응답 포맷 개선
- 에러 응답에 `path`, `timestamp`, `errors` 필드 추가
- Validation 오류 발생 시 필드별 에러 메시지 반환
- 인증 실패 응답도 공통 `ErrorResponse` 형식으로 통일
- 예상 가능한 예외 응답의 메시지 전달 구조 개선

## 📌 담당 영역

- [x] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [x] 문서 / 기타

## 🔗 관련 이슈

- closes #25 

## 🧩 API / DB 변경 사항

- API 경로 변경 없음
- DB 변경 없음
- 에러 응답 body 형식 개선

예시 응답:

{
  "code": "INVALID_REQUEST",
  "message": "요청값이 올바르지 않습니다.",
  "path": "/api/auth/login",
  "timestamp": "2026-07-09T22:43:24.8721426",
  "errors": [
    {
      "field": "idToken",
      "message": "ID Token은 필수입니다."
    }
  ]
}

## ✅ 테스트

- [x] 서버 실행 확인
- [x] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

- 전체 테스트 통과
- Validation 오류 응답 포맷 수동 확인
- 인증 실패 응답 포맷 수동 확인

## 💬 참고 사항

- 기존 사용자 재로그인 오류 수정 과정에서 500 응답 메시지가 짧아 원인 파악이 어렵다는 의견이 있어 전역 예외 응답 포맷을 개선
- 인증 실패 응답은 `JwtAuthenticationEntryPoint`에서 처리되므로 공통 `ErrorResponse` 형식에 맞춰 별도 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 오류 응답에 요청 경로와 시간 정보가 포함되며, 필드별 검증 오류도 함께 표시됩니다.
* **Bug Fixes**
  * 인증 실패 및 각종 예외 응답 형식이 더 일관되게 정리되었습니다.
  * 입력값 검증 실패 시 모든 오류 항목을 한 번에 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->