### PR TITLE
feat(course): 추천 코스 후보 조회 API 구현

### DIFF
--- a/src/main/java/com/chaerok/backend/course/controller/CourseController.java
+++ b/src/main/java/com/chaerok/backend/course/controller/CourseController.java
@@ -1,0 +1,36 @@
+package com.chaerok.backend.course.controller;
+
+import com.chaerok.backend.course.dto.CourseRecommendResponse;
+import com.chaerok.backend.course.service.CourseRecommendService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Course", description = "추천 코스 후보 조회 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/courses")
+public class CourseController {
+
+    private final CourseRecommendService courseRecommendService;
+
+    @Operation(
+            summary = "추천 코스 후보 조회",
+            description = "regionId 또는 anchorPlaceId를 기준으로 대표 장소 Anchor와 Kakao Local 음식점·카페 후보를 조합한 추천 코스 후보를 조회한다. 사용자 원본 좌표는 전달받지 않는다."
+    )
+    @GetMapping("/recommend")
+    public ResponseEntity<CourseRecommendResponse> recommendCourses(
+            @RequestParam Long regionId,
+            @RequestParam(required = false) Long anchorPlaceId
+    ) {
+        return ResponseEntity.ok(courseRecommendService.recommendCourses(
+                regionId,
+                anchorPlaceId
+        ));
+    }
+}

--- a/src/main/java/com/chaerok/backend/course/dto/CoursePlaceResponse.java
+++ b/src/main/java/com/chaerok/backend/course/dto/CoursePlaceResponse.java
@@ -1,0 +1,73 @@
+package com.chaerok.backend.course.dto;
+
+import com.chaerok.backend.place.entity.Place;
+import com.chaerok.backend.place.entity.PlaceCategoryDetail;
+import com.chaerok.backend.place.entity.PlaceCategoryGroup;
+import com.chaerok.backend.place.entity.PlaceSource;
+import com.chaerok.backend.place.external.KakaoPlaceItem;
+
+public record CoursePlaceResponse(
+        Long placeId,
+        String externalPlaceId,
+        String source,
+        String title,
+        String categoryGroup,
+        String categoryDetail,
+        String address,
+        String placeUrl
+) {
+
+    public static CoursePlaceResponse fromPlace(Place place) {
+        return new CoursePlaceResponse(
+                place.getId(),
+                place.getKakaoPlaceId(),
+                place.getSource().name(),
+                place.getTitle(),
+                place.getCategoryGroup().name(),
+                place.getCategoryDetail() == null ? null : place.getCategoryDetail().name(),
+                place.getAddress(),
+                null
+        );
+    }
+
+    public static CoursePlaceResponse fromKakaoFood(KakaoPlaceItem item) {
+        return fromKakao(
+                item,
+                PlaceCategoryGroup.FOOD,
+                PlaceCategoryDetail.RESTAURANT
+        );
+    }
+
+    public static CoursePlaceResponse fromKakaoCafe(KakaoPlaceItem item) {
+        return fromKakao(
+                item,
+                PlaceCategoryGroup.CAFE_DESSERT,
+                PlaceCategoryDetail.CAFE
+        );
+    }
+
+    private static CoursePlaceResponse fromKakao(
+            KakaoPlaceItem item,
+            PlaceCategoryGroup categoryGroup,
+            PlaceCategoryDetail categoryDetail
+    ) {
+        return new CoursePlaceResponse(
+                null,
+                item.id(),
+                PlaceSource.KAKAO_LOCAL.name(),
+                item.placeName(),
+                categoryGroup.name(),
+                categoryDetail.name(),
+                getAddress(item),
+                item.placeUrl()
+        );
+    }
+
+    private static String getAddress(KakaoPlaceItem item) {
+        if (item.roadAddressName() != null && !item.roadAddressName().isBlank()) {
+            return item.roadAddressName();
+        }
+
+        return item.addressName();
+    }
+}

--- a/src/main/java/com/chaerok/backend/course/dto/CourseRecommendResponse.java
+++ b/src/main/java/com/chaerok/backend/course/dto/CourseRecommendResponse.java
@@ -1,0 +1,11 @@
+package com.chaerok.backend.course.dto;
+
+import java.util.List;
+
+public record CourseRecommendResponse(
+        Long regionId,
+        String recommendationType,
+        Long anchorPlaceId,
+        List<CourseResponse> courses
+) {
+}

--- a/src/main/java/com/chaerok/backend/course/dto/CourseResponse.java
+++ b/src/main/java/com/chaerok/backend/course/dto/CourseResponse.java
@@ -1,0 +1,10 @@
+package com.chaerok.backend.course.dto;
+
+import java.util.List;
+
+public record CourseResponse(
+        String title,
+        double score,
+        List<CoursePlaceResponse> places
+) {
+}

--- a/src/main/java/com/chaerok/backend/course/service/CourseRecommendService.java
+++ b/src/main/java/com/chaerok/backend/course/service/CourseRecommendService.java
@@ -1,0 +1,308 @@
+package com.chaerok.backend.course.service;
+
+import com.chaerok.backend.course.dto.CoursePlaceResponse;
+import com.chaerok.backend.course.dto.CourseRecommendResponse;
+import com.chaerok.backend.course.dto.CourseResponse;
+import com.chaerok.backend.global.exception.PlaceNotFoundException;
+import com.chaerok.backend.global.exception.RegionNotFoundException;
+import com.chaerok.backend.place.entity.Place;
+import com.chaerok.backend.place.entity.PlaceCategoryDetail;
+import com.chaerok.backend.place.entity.PlaceCategoryGroup;
+import com.chaerok.backend.place.external.KakaoLocalClient;
+import com.chaerok.backend.place.external.KakaoPlaceItem;
+import com.chaerok.backend.place.repository.PlaceRepository;
+import com.chaerok.backend.region.repository.RegionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CourseRecommendService {
+
+    private static final String RECOMMENDATION_TYPE_REGION = "REGION";
+    private static final String RECOMMENDATION_TYPE_ANCHOR = "ANCHOR";
+
+    private static final String KAKAO_CATEGORY_FOOD = "FD6";
+    private static final String KAKAO_CATEGORY_CAFE = "CE7";
+
+    private static final int DEFAULT_SEARCH_RADIUS = 2000;
+    private static final int EXTENDED_SEARCH_RADIUS = 5000;
+    private static final int MAX_REGION_ANCHOR_COUNT = 3;
+    private static final int MAX_COURSE_PLACE_COUNT = 3;
+
+    private final RegionRepository regionRepository;
+    private final PlaceRepository placeRepository;
+    private final KakaoLocalClient kakaoLocalClient;
+
+    public CourseRecommendResponse recommendCourses(
+            Long regionId,
+            Long anchorPlaceId
+    ) {
+        validateRegion(regionId);
+
+        List<Place> representativePlaces =
+                placeRepository.findByRegionIdAndRepresentativeTrue(regionId);
+
+        if (anchorPlaceId != null) {
+            Place anchor = findAnchor(regionId, anchorPlaceId);
+
+            return new CourseRecommendResponse(
+                    regionId,
+                    RECOMMENDATION_TYPE_ANCHOR,
+                    anchor.getId(),
+                    List.of(createCourse(anchor, representativePlaces))
+            );
+        }
+
+        List<Place> anchors = findRegionAnchors(representativePlaces);
+
+        List<CourseResponse> courses = anchors.stream()
+                .map(anchor -> createCourse(anchor, representativePlaces))
+                .toList();
+
+        Long firstAnchorPlaceId = anchors.isEmpty() ? null : anchors.get(0).getId();
+
+        return new CourseRecommendResponse(
+                regionId,
+                RECOMMENDATION_TYPE_REGION,
+                firstAnchorPlaceId,
+                courses
+        );
+    }
+
+    private void validateRegion(Long regionId) {
+        if (!regionRepository.existsById(regionId)) {
+            throw new RegionNotFoundException();
+        }
+    }
+
+    private Place findAnchor(
+            Long regionId,
+            Long anchorPlaceId
+    ) {
+        Place anchor = placeRepository.findById(anchorPlaceId)
+                .orElseThrow(PlaceNotFoundException::new);
+
+        if (!anchor.getRegion().getId().equals(regionId)) {
+            throw new IllegalArgumentException("해당 지역의 Anchor 장소가 아닙니다.");
+        }
+
+        if (!anchor.isRepresentative()) {
+            throw new IllegalArgumentException("대표 장소만 Anchor로 사용할 수 있습니다.");
+        }
+
+        if (!hasCoordinate(anchor)) {
+            throw new IllegalArgumentException("Anchor 장소의 좌표 정보가 없습니다.");
+        }
+
+        return anchor;
+    }
+
+    private List<Place> findRegionAnchors(List<Place> representativePlaces) {
+        return representativePlaces.stream()
+                .filter(this::hasCoordinate)
+                .filter(place -> place.getCategoryGroup() == PlaceCategoryGroup.TOURISM)
+                .sorted(Comparator
+                        .comparingInt(this::getAnchorPriority)
+                        .thenComparing(Place::getId))
+                .limit(MAX_REGION_ANCHOR_COUNT)
+                .toList();
+    }
+
+    private CourseResponse createCourse(
+            Place anchor,
+            List<Place> representativePlaces
+    ) {
+        List<CoursePlaceResponse> places = new ArrayList<>();
+
+        places.add(CoursePlaceResponse.fromPlace(anchor));
+
+        findFirstFoodCandidate(anchor)
+                .map(CoursePlaceResponse::fromKakaoFood)
+                .ifPresent(places::add);
+
+        findFirstCafeCandidate(anchor)
+                .map(CoursePlaceResponse::fromKakaoCafe)
+                .ifPresent(places::add);
+
+        if (places.size() < MAX_COURSE_PLACE_COUNT) {
+            addFallbackPlaces(anchor, representativePlaces, places);
+        }
+
+        return new CourseResponse(
+                createCourseTitle(anchor),
+                calculateScore(anchor, places),
+                places
+        );
+    }
+
+    private java.util.Optional<KakaoPlaceItem> findFirstFoodCandidate(Place anchor) {
+        return searchKakaoCandidates(anchor, KAKAO_CATEGORY_FOOD).stream()
+                .findFirst();
+    }
+
+    private java.util.Optional<KakaoPlaceItem> findFirstCafeCandidate(Place anchor) {
+        return searchKakaoCandidates(anchor, KAKAO_CATEGORY_CAFE).stream()
+                .findFirst();
+    }
+
+    private List<KakaoPlaceItem> searchKakaoCandidates(
+            Place anchor,
+            String categoryGroupCode
+    ) {
+        List<KakaoPlaceItem> candidates = kakaoLocalClient.searchPlacesByCategory(
+                categoryGroupCode,
+                anchor.getLongitude(),
+                anchor.getLatitude(),
+                DEFAULT_SEARCH_RADIUS
+        );
+
+        if (!candidates.isEmpty()) {
+            return candidates;
+        }
+
+        return kakaoLocalClient.searchPlacesByCategory(
+                categoryGroupCode,
+                anchor.getLongitude(),
+                anchor.getLatitude(),
+                EXTENDED_SEARCH_RADIUS
+        );
+    }
+
+    private void addFallbackPlaces(
+            Place anchor,
+            List<Place> representativePlaces,
+            List<CoursePlaceResponse> places
+    ) {
+        List<Place> fallbackPlaces = representativePlaces.stream()
+                .filter(this::hasCoordinate)
+                .filter(place -> !place.getId().equals(anchor.getId()))
+                .filter(place -> !containsPlace(places, place.getId()))
+                .sorted(Comparator.comparingDouble(place -> calculateDistanceMeters(anchor, place)))
+                .toList();
+
+        for (Place fallbackPlace : fallbackPlaces) {
+            if (places.size() >= MAX_COURSE_PLACE_COUNT) {
+                return;
+            }
+
+            places.add(CoursePlaceResponse.fromPlace(fallbackPlace));
+        }
+    }
+
+    private boolean containsPlace(
+            List<CoursePlaceResponse> places,
+            Long placeId
+    ) {
+        return places.stream()
+                .anyMatch(place -> placeId.equals(place.placeId()));
+    }
+
+    private String createCourseTitle(Place anchor) {
+        return anchor.getTitle() + " 중심 소도시 탐방 코스";
+    }
+
+    private double calculateScore(
+            Place anchor,
+            List<CoursePlaceResponse> places
+    ) {
+        double score = 60.0;
+
+        if (places.size() >= MAX_COURSE_PLACE_COUNT) {
+            score += 10.0;
+        }
+
+        if (containsCategoryGroup(places, PlaceCategoryGroup.FOOD)) {
+            score += 10.0;
+        }
+
+        if (containsCategoryGroup(places, PlaceCategoryGroup.CAFE_DESSERT)) {
+            score += 10.0;
+        }
+
+        if (isHeritageAnchor(anchor)) {
+            score += 10.0;
+        }
+
+        return Math.min(score, 100.0);
+    }
+
+    private boolean containsCategoryGroup(
+            List<CoursePlaceResponse> places,
+            PlaceCategoryGroup categoryGroup
+    ) {
+        return places.stream()
+                .anyMatch(place -> categoryGroup.name().equals(place.categoryGroup()));
+    }
+
+    private boolean isHeritageAnchor(Place anchor) {
+        return anchor.getCategoryDetail() == PlaceCategoryDetail.HERITAGE;
+    }
+
+    private int getAnchorPriority(Place place) {
+        PlaceCategoryDetail categoryDetail = place.getCategoryDetail();
+
+        if (categoryDetail == PlaceCategoryDetail.HERITAGE) {
+            return 1;
+        }
+
+        if (categoryDetail == PlaceCategoryDetail.NATURE) {
+            return 2;
+        }
+
+        if (categoryDetail == PlaceCategoryDetail.WALK) {
+            return 3;
+        }
+
+        if (categoryDetail == PlaceCategoryDetail.MARKET) {
+            return 4;
+        }
+
+        return 5;
+    }
+
+    private boolean hasCoordinate(Place place) {
+        return place.getLatitude() != null && place.getLongitude() != null;
+    }
+
+    private double calculateDistanceMeters(
+            Place from,
+            Place to
+    ) {
+        return calculateDistanceMeters(
+                from.getLatitude(),
+                from.getLongitude(),
+                to.getLatitude(),
+                to.getLongitude()
+        );
+    }
+
+    private double calculateDistanceMeters(
+            BigDecimal latitude1,
+            BigDecimal longitude1,
+            BigDecimal latitude2,
+            BigDecimal longitude2
+    ) {
+        double earthRadiusMeters = 6371000.0;
+
+        double lat1 = Math.toRadians(latitude1.doubleValue());
+        double lat2 = Math.toRadians(latitude2.doubleValue());
+        double deltaLat = Math.toRadians(latitude2.subtract(latitude1).doubleValue());
+        double deltaLon = Math.toRadians(longitude2.subtract(longitude1).doubleValue());
+
+        double a = Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2)
+                + Math.cos(lat1) * Math.cos(lat2)
+                * Math.sin(deltaLon / 2) * Math.sin(deltaLon / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return earthRadiusMeters * c;
+    }
+}

--- a/src/main/java/com/chaerok/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/chaerok/backend/global/config/SecurityConfig.java
@@ -43,6 +43,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/health",
                                 "/api/auth/**",
+                                "/api/places/**",
+                                "/api/courses/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**",

--- a/src/main/java/com/chaerok/backend/place/external/KakaoLocalClient.java
+++ b/src/main/java/com/chaerok/backend/place/external/KakaoLocalClient.java
@@ -19,7 +19,11 @@ public class KakaoLocalClient {
 
     private static final String BASE_URL = "https://dapi.kakao.com";
     private static final String KEYWORD_SEARCH_PATH = "/v2/local/search/keyword.json";
+    private static final String CATEGORY_SEARCH_PATH = "/v2/local/search/category.json";
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+    private static final int DEFAULT_RADIUS = 10000;
+    private static final int DEFAULT_SIZE = 15;
 
     private final WebClient.Builder webClientBuilder;
 
@@ -45,8 +49,8 @@ public class KakaoLocalClient {
                             .queryParam("query", keyword)
                             .queryParam("x", longitude)
                             .queryParam("y", latitude)
-                            .queryParam("radius", 10000)
-                            .queryParam("size", 15)
+                            .queryParam("radius", DEFAULT_RADIUS)
+                            .queryParam("size", DEFAULT_SIZE)
                             .build())
                     .header("Authorization", "KakaoAK " + restApiKey)
                     .retrieve()
@@ -70,6 +74,60 @@ public class KakaoLocalClient {
         } catch (RuntimeException e) {
             log.error("Kakao Local keyword search unexpected error. keyword={}, message={}",
                     keyword, e.getMessage(), e);
+            return List.of();
+        }
+    }
+
+    public List<KakaoPlaceItem> searchPlacesByCategory(
+            String categoryGroupCode,
+            BigDecimal longitude,
+            BigDecimal latitude,
+            int radius
+    ) {
+        if (categoryGroupCode == null || categoryGroupCode.isBlank()) {
+            return List.of();
+        }
+
+        if (longitude == null || latitude == null) {
+            return List.of();
+        }
+
+        try {
+            KakaoPlaceResponse response = webClientBuilder
+                    .baseUrl(BASE_URL)
+                    .build()
+                    .get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path(CATEGORY_SEARCH_PATH)
+                            .queryParam("category_group_code", categoryGroupCode)
+                            .queryParam("x", longitude)
+                            .queryParam("y", latitude)
+                            .queryParam("radius", radius)
+                            .queryParam("size", DEFAULT_SIZE)
+                            .queryParam("sort", "distance")
+                            .build())
+                    .header("Authorization", "KakaoAK " + restApiKey)
+                    .retrieve()
+                    .bodyToMono(KakaoPlaceResponse.class)
+                    .timeout(REQUEST_TIMEOUT)
+                    .block();
+
+            if (response == null) {
+                return List.of();
+            }
+
+            return response.getItems();
+        } catch (WebClientResponseException e) {
+            log.warn("Kakao Local category search response error. categoryGroupCode={}, status={}, body={}",
+                    categoryGroupCode, e.getStatusCode(), e.getResponseBodyAsString());
+            return List.of();
+        } catch (WebClientRequestException e) {
+            log.warn("Kakao Local category search request error. categoryGroupCode={}, message={}",
+                    categoryGroupCode, e.getMessage());
+            return List.of();
+        } catch (RuntimeException e) {
+            log.error("Kakao Local category search unexpected error. categoryGroupCode={}, message={}",
+                    categoryGroupCode, e.getMessage(), e);
             return List.of();
         }
     }


### PR DESCRIPTION
## ✨ 변경 사항

- Course 1차 추천 코스 후보 조회 API 구현
- `regionId` 기반 여행 전 추천 코스 후보 조회 처리
- `anchorPlaceId` 기반 Anchor 중심 추천 코스 후보 조회 처리
- 대표 장소 Anchor와 Kakao Local 음식점·카페 후보 조합 로직 추가
- Kakao Local 카테고리 검색 API 호출 메서드 추가
- Course 추천 API 공개 접근 허용 처리

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #30 

## 🧩 API / DB 변경 사항

### API 추가

- `GET /api/courses/recommend?regionId={regionId}`
- `GET /api/courses/recommend?regionId={regionId}&anchorPlaceId={anchorPlaceId}`

### API 응답

- 대표 장소 Anchor
- Kakao Local 음식점 후보
- Kakao Local 카페·디저트 후보
- 장소 source, externalPlaceId, placeUrl 포함

### DB 변경 사항

- 없음

## ✅ 테스트

- [x] 서버 실행 확인
- [x] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- Course 1차는 코스 저장 기능이 아니라 추천 후보 조회 기능으로 구현
- 사용자 원본 GPS 좌표는 백엔드에서 수신하지 않음
- Kakao Local 후보는 추천 응답에만 포함하고 DB에 저장하지 않음
- 대표 장소 Anchor는 DB의 `is_representative = true` 장소 기준으로 사용
- 별점 기반 필터링은 1차 구현 범위에서 제외
- 대표 장소 방문 가산점은 추후 방문 인증/필름 롤 진행 정책과 연결 예정
- Place/Course 조회 API는 사용자 개인 정보 없이 관광 장소 및 추천 후보만 반환하므로 1차에서는 공개 API로 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 지역을 기반으로 맞춤형 여행 코스를 추천받을 수 있습니다.
  - 특정 장소를 출발점으로 지정해 주변 음식점·카페·관광지를 포함한 코스를 추천받을 수 있습니다.
  - 추천 코스마다 제목, 점수, 포함 장소 정보가 제공됩니다.
  - 장소 정보에 주소, 카테고리, 상세 링크가 포함됩니다.

- **개선 사항**
  - 코스 및 장소 추천 기능을 별도 인증 없이 이용할 수 있습니다.
  - 주변 장소 검색 결과를 거리순으로 반영해 더욱 적합한 코스를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->