### PR TITLE
feat(course): 사용자 선택 코스 저장 기능 구현

### DIFF
--- a/src/main/java/com/chaerok/backend/course/controller/CourseController.java
+++ b/src/main/java/com/chaerok/backend/course/controller/CourseController.java
@@ -1,27 +1,35 @@
 package com.chaerok.backend.course.controller;
 
+import com.chaerok.backend.auth.security.AuthenticatedUser;
+import com.chaerok.backend.course.dto.CourseAddPlacesRequest;
+import com.chaerok.backend.course.dto.CourseCreateRequest;
 import com.chaerok.backend.course.dto.CourseRecommendResponse;
+import com.chaerok.backend.course.dto.SelectedCourseResponse;
+import com.chaerok.backend.course.service.CourseCommandService;
 import com.chaerok.backend.course.service.CourseRecommendService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Course", description = "추천 코스 후보 조회 API")
+@Tag(name = "Course", description = "추천 코스 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/courses")
 public class CourseController {
 
     private final CourseRecommendService courseRecommendService;
+    private final CourseCommandService courseCommandService;
 
     @Operation(
             summary = "추천 코스 후보 조회",
-            description = "regionId 또는 anchorPlaceId를 기준으로 대표 장소 Anchor와 Kakao Local 음식점·카페 후보를 조합한 추천 코스 후보를 조회한다. 사용자 원본 좌표는 전달받지 않는다."
+            description = """
+                    regionId 또는 anchorPlaceId를 기준으로 대표 장소 Anchor와 Kakao Local 음식점·카페 후보를 조합한 추천 코스 후보를 조회한다.
+                    사용자 원본 좌표는 전달받지 않는다.
+                    """
     )
     @GetMapping("/recommend")
     public ResponseEntity<CourseRecommendResponse> recommendCourses(
@@ -31,6 +39,57 @@ public class CourseController {
         return ResponseEntity.ok(courseRecommendService.recommendCourses(
                 regionId,
                 anchorPlaceId
+        ));
+    }
+
+    @Operation(
+            summary = "사용자 선택 코스 생성",
+            description = """
+                    사용자가 선택한 장소 1~3개로 ACTIVE 코스를 생성한다.
+                    기존 ACTIVE 코스가 있으면 INACTIVE 처리하고 새 ACTIVE 코스를 생성한다.
+                    """
+    )
+    @PostMapping
+    public ResponseEntity<SelectedCourseResponse> createCourse(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @Valid @RequestBody CourseCreateRequest request
+    ) {
+        return ResponseEntity.ok(courseCommandService.createCourse(
+                authenticatedUser.userId(),
+                request
+        ));
+    }
+
+    @Operation(
+            summary = "ACTIVE 코스 장소 추가",
+            description = """
+                    로그인 사용자의 ACTIVE 코스에 장소를 추가한다.
+                    ACTIVE 코스는 최대 3개 장소까지만 저장할 수 있다.
+                    """
+    )
+    @PostMapping("/active/places")
+    public ResponseEntity<SelectedCourseResponse> addPlacesToActiveCourse(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @Valid @RequestBody CourseAddPlacesRequest request
+    ) {
+        return ResponseEntity.ok(
+                courseCommandService.addPlacesToActiveCourse(
+                        authenticatedUser.userId(),
+                        request
+                )
+        );
+    }
+
+    @Operation(
+            summary = "ACTIVE 코스 조회",
+            description = "로그인 사용자의 현재 ACTIVE 코스를 조회한다."
+    )
+    @GetMapping("/active")
+    public ResponseEntity<SelectedCourseResponse> getActiveCourse(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        return ResponseEntity.ok(courseCommandService.getActiveCourse(
+                authenticatedUser.userId()
         ));
     }
 }

--- a/src/main/java/com/chaerok/backend/course/dto/CourseAddPlacesRequest.java
+++ b/src/main/java/com/chaerok/backend/course/dto/CourseAddPlacesRequest.java
@@ -1,0 +1,13 @@
+package com.chaerok.backend.course.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record CourseAddPlacesRequest(
+        @Valid
+        @Size(min = 1, max = 3, message = "추가할 장소는 1개 이상 3개 이하로 선택해야 합니다.")
+        List<CoursePlaceSaveRequest> places
+) {
+}

--- a/src/main/java/com/chaerok/backend/course/dto/CourseCreateRequest.java
+++ b/src/main/java/com/chaerok/backend/course/dto/CourseCreateRequest.java
@@ -1,0 +1,21 @@
+package com.chaerok.backend.course.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record CourseCreateRequest(
+        @NotNull(message = "지역 ID는 필수입니다.")
+        Long regionId,
+
+        @NotBlank(message = "코스 제목은 필수입니다.")
+        String title,
+
+        @Valid
+        @Size(min = 1, max = 3, message = "코스 장소는 1개 이상 3개 이하로 선택해야 합니다.")
+        List<CoursePlaceSaveRequest> places
+) {
+}

--- a/src/main/java/com/chaerok/backend/course/dto/CoursePlaceResponse.java
+++ b/src/main/java/com/chaerok/backend/course/dto/CoursePlaceResponse.java
@@ -24,7 +24,7 @@ public record CoursePlaceResponse(
     public static CoursePlaceResponse fromPlace(Place place) {
         return new CoursePlaceResponse(
                 place.getId(),
-                place.getKakaoPlaceId(),
+                getExternalPlaceId(place),
                 place.getSource().name(),
                 place.getTitle(),
                 place.getCategoryGroup().name(),
@@ -92,5 +92,13 @@ public record CoursePlaceResponse(
         } catch (NumberFormatException exception) {
             return null;
         }
+    }
+
+    private static String getExternalPlaceId(Place place) {
+        if (PlaceSource.TOUR_API.equals(place.getSource())) {
+            return place.getTourContentId();
+        }
+
+        return place.getKakaoPlaceId();
     }
 }

--- a/src/main/java/com/chaerok/backend/course/dto/CoursePlaceResponse.java
+++ b/src/main/java/com/chaerok/backend/course/dto/CoursePlaceResponse.java
@@ -6,6 +6,8 @@ import com.chaerok.backend.place.entity.PlaceCategoryGroup;
 import com.chaerok.backend.place.entity.PlaceSource;
 import com.chaerok.backend.place.external.KakaoPlaceItem;
 
+import java.math.BigDecimal;
+
 public record CoursePlaceResponse(
         Long placeId,
         String externalPlaceId,
@@ -14,6 +16,8 @@ public record CoursePlaceResponse(
         String categoryGroup,
         String categoryDetail,
         String address,
+        BigDecimal latitude,
+        BigDecimal longitude,
         String placeUrl
 ) {
 
@@ -24,8 +28,12 @@ public record CoursePlaceResponse(
                 place.getSource().name(),
                 place.getTitle(),
                 place.getCategoryGroup().name(),
-                place.getCategoryDetail() == null ? null : place.getCategoryDetail().name(),
+                place.getCategoryDetail() == null
+                        ? null
+                        : place.getCategoryDetail().name(),
                 place.getAddress(),
+                place.getLatitude(),
+                place.getLongitude(),
                 null
         );
     }
@@ -59,15 +67,30 @@ public record CoursePlaceResponse(
                 categoryGroup.name(),
                 categoryDetail.name(),
                 getAddress(item),
+                toBigDecimal(item.y()),
+                toBigDecimal(item.x()),
                 item.placeUrl()
         );
     }
 
     private static String getAddress(KakaoPlaceItem item) {
-        if (item.roadAddressName() != null && !item.roadAddressName().isBlank()) {
+        if (item.roadAddressName() != null
+                && !item.roadAddressName().isBlank()) {
             return item.roadAddressName();
         }
 
         return item.addressName();
+    }
+
+    private static BigDecimal toBigDecimal(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        try {
+            return new BigDecimal(value);
+        } catch (NumberFormatException exception) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/chaerok/backend/course/dto/CoursePlaceSaveRequest.java
+++ b/src/main/java/com/chaerok/backend/course/dto/CoursePlaceSaveRequest.java
@@ -1,0 +1,24 @@
+package com.chaerok.backend.course.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.math.BigDecimal;
+
+public record CoursePlaceSaveRequest(
+        Long placeId,
+        String externalPlaceId,
+        String source,
+
+        @NotBlank(message = "장소명은 필수입니다.")
+        String title,
+
+        @NotBlank(message = "장소 유형은 필수입니다.")
+        String categoryGroup,
+
+        String categoryDetail,
+        String address,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        String placeUrl
+) {
+}

--- a/src/main/java/com/chaerok/backend/course/dto/SelectedCoursePlaceResponse.java
+++ b/src/main/java/com/chaerok/backend/course/dto/SelectedCoursePlaceResponse.java
@@ -1,0 +1,31 @@
+package com.chaerok.backend.course.dto;
+
+import com.chaerok.backend.course.entity.CoursePlace;
+import com.chaerok.backend.place.entity.Place;
+
+public record SelectedCoursePlaceResponse(
+        Long placeId,
+        String source,
+        String title,
+        String categoryGroup,
+        String categoryDetail,
+        String address,
+        Integer sequence
+) {
+
+    public static SelectedCoursePlaceResponse from(CoursePlace coursePlace) {
+        Place place = coursePlace.getPlace();
+
+        return new SelectedCoursePlaceResponse(
+                place.getId(),
+                place.getSource().name(),
+                place.getTitle(),
+                place.getCategoryGroup().name(),
+                place.getCategoryDetail() == null
+                        ? null
+                        : place.getCategoryDetail().name(),
+                place.getAddress(),
+                coursePlace.getSequence()
+        );
+    }
+}

--- a/src/main/java/com/chaerok/backend/course/dto/SelectedCourseResponse.java
+++ b/src/main/java/com/chaerok/backend/course/dto/SelectedCourseResponse.java
@@ -1,0 +1,36 @@
+package com.chaerok.backend.course.dto;
+
+import com.chaerok.backend.course.entity.Course;
+import com.chaerok.backend.course.entity.CoursePlace;
+
+import java.util.List;
+
+public record SelectedCourseResponse(
+        Long courseId,
+        Long regionId,
+        String title,
+        String status,
+        int placeCount,
+        boolean completed,
+        List<SelectedCoursePlaceResponse> places
+) {
+
+    public static SelectedCourseResponse of(
+            Course course,
+            List<CoursePlace> coursePlaces
+    ) {
+        int placeCount = coursePlaces.size();
+
+        return new SelectedCourseResponse(
+                course.getId(),
+                course.getRegion().getId(),
+                course.getTitle(),
+                course.getStatus().name(),
+                placeCount,
+                placeCount == 3,
+                coursePlaces.stream()
+                        .map(SelectedCoursePlaceResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/chaerok/backend/course/entity/Course.java
+++ b/src/main/java/com/chaerok/backend/course/entity/Course.java
@@ -1,0 +1,63 @@
+package com.chaerok.backend.course.entity;
+
+import com.chaerok.backend.region.entity.Region;
+import com.chaerok.backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "courses")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Course {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "region_id", nullable = false)
+    private Region region;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private CourseStatus status;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static Course create(
+            User user,
+            Region region,
+            String title
+    ) {
+        Course course = new Course();
+        course.user = user;
+        course.region = region;
+        course.title = title;
+        course.status = CourseStatus.ACTIVE;
+        return course;
+    }
+
+    public void inactive() {
+        this.status = CourseStatus.INACTIVE;
+    }
+}

--- a/src/main/java/com/chaerok/backend/course/entity/CoursePlace.java
+++ b/src/main/java/com/chaerok/backend/course/entity/CoursePlace.java
@@ -1,0 +1,60 @@
+package com.chaerok.backend.course.entity;
+
+import com.chaerok.backend.place.entity.Place;
+import com.chaerok.backend.place.entity.PlaceCategoryDetail;
+import com.chaerok.backend.place.entity.PlaceCategoryGroup;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "course_places")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CoursePlace {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
+
+    @Column(nullable = false)
+    private Integer sequence;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category_group", nullable = false, length = 30)
+    private PlaceCategoryGroup categoryGroup;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category_detail", length = 30)
+    private PlaceCategoryDetail categoryDetail;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static CoursePlace create(
+            Course course,
+            Place place,
+            Integer sequence
+    ) {
+        CoursePlace coursePlace = new CoursePlace();
+        coursePlace.course = course;
+        coursePlace.place = place;
+        coursePlace.sequence = sequence;
+        coursePlace.categoryGroup = place.getCategoryGroup();
+        coursePlace.categoryDetail = place.getCategoryDetail();
+        return coursePlace;
+    }
+}

--- a/src/main/java/com/chaerok/backend/course/entity/CourseStatus.java
+++ b/src/main/java/com/chaerok/backend/course/entity/CourseStatus.java
@@ -1,0 +1,7 @@
+package com.chaerok.backend.course.entity;
+
+public enum CourseStatus {
+    ACTIVE,
+    INACTIVE,
+    EXPIRED
+}

--- a/src/main/java/com/chaerok/backend/course/repository/CoursePlaceRepository.java
+++ b/src/main/java/com/chaerok/backend/course/repository/CoursePlaceRepository.java
@@ -1,0 +1,24 @@
+package com.chaerok.backend.course.repository;
+
+import com.chaerok.backend.course.entity.CoursePlace;
+import com.chaerok.backend.place.entity.PlaceCategoryGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CoursePlaceRepository extends JpaRepository<CoursePlace, Long> {
+
+    List<CoursePlace> findByCourseIdOrderBySequenceAsc(Long courseId);
+
+    int countByCourseId(Long courseId);
+
+    boolean existsByCourseIdAndPlaceId(
+            Long courseId,
+            Long placeId
+    );
+
+    boolean existsByCourseIdAndCategoryGroup(
+            Long courseId,
+            PlaceCategoryGroup categoryGroup
+    );
+}

--- a/src/main/java/com/chaerok/backend/course/repository/CourseRepository.java
+++ b/src/main/java/com/chaerok/backend/course/repository/CourseRepository.java
@@ -1,0 +1,21 @@
+package com.chaerok.backend.course.repository;
+
+import com.chaerok.backend.course.entity.Course;
+import com.chaerok.backend.course.entity.CourseStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+
+    List<Course> findAllByUserIdAndStatus(
+            Long userId,
+            CourseStatus status
+    );
+
+    Optional<Course> findByUserIdAndStatus(
+            Long userId,
+            CourseStatus status
+    );
+}

--- a/src/main/java/com/chaerok/backend/course/service/CourseCommandService.java
+++ b/src/main/java/com/chaerok/backend/course/service/CourseCommandService.java
@@ -1,0 +1,476 @@
+package com.chaerok.backend.course.service;
+
+import com.chaerok.backend.course.dto.CourseAddPlacesRequest;
+import com.chaerok.backend.course.dto.CourseCreateRequest;
+import com.chaerok.backend.course.dto.CoursePlaceSaveRequest;
+import com.chaerok.backend.course.dto.SelectedCourseResponse;
+import com.chaerok.backend.course.entity.Course;
+import com.chaerok.backend.course.entity.CoursePlace;
+import com.chaerok.backend.course.entity.CourseStatus;
+import com.chaerok.backend.course.repository.CoursePlaceRepository;
+import com.chaerok.backend.course.repository.CourseRepository;
+import com.chaerok.backend.global.exception.PlaceNotFoundException;
+import com.chaerok.backend.global.exception.RegionNotFoundException;
+import com.chaerok.backend.place.entity.Place;
+import com.chaerok.backend.place.entity.PlaceCategoryDetail;
+import com.chaerok.backend.place.entity.PlaceCategoryGroup;
+import com.chaerok.backend.place.entity.PlaceSource;
+import com.chaerok.backend.place.external.TourApiPlaceClient;
+import com.chaerok.backend.place.external.TourApiPlaceItem;
+import com.chaerok.backend.place.repository.PlaceRepository;
+import com.chaerok.backend.place.service.PlaceCategoryMapper;
+import com.chaerok.backend.region.entity.Region;
+import com.chaerok.backend.region.repository.RegionRepository;
+import com.chaerok.backend.user.entity.User;
+import com.chaerok.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CourseCommandService {
+
+    private static final int MAX_COURSE_PLACE_COUNT = 3;
+
+    private final CourseRepository courseRepository;
+    private final CoursePlaceRepository coursePlaceRepository;
+    private final UserRepository userRepository;
+    private final RegionRepository regionRepository;
+    private final PlaceRepository placeRepository;
+    private final TourApiPlaceClient tourApiPlaceClient;
+
+    public SelectedCourseResponse createCourse(
+            Long userId,
+            CourseCreateRequest request
+    ) {
+        validatePlaceRequestSize(request.places());
+
+        User user = findUser(userId);
+        Region region = findRegion(request.regionId());
+
+        inactiveActiveCourses(userId);
+
+        Course course = courseRepository.save(
+                Course.create(user, region, request.title())
+        );
+
+        addPlaces(course, region, request.places());
+
+        return getCourseResponse(course);
+    }
+
+    public SelectedCourseResponse addPlacesToActiveCourse(
+            Long userId,
+            CourseAddPlacesRequest request
+    ) {
+        validatePlaceRequestSize(request.places());
+
+        Course course = findActiveCourse(userId);
+        Region region = course.getRegion();
+
+        int currentPlaceCount = coursePlaceRepository.countByCourseId(
+                course.getId()
+        );
+
+        if (currentPlaceCount + request.places().size()
+                > MAX_COURSE_PLACE_COUNT) {
+            throw new IllegalArgumentException(
+                    "ACTIVE 코스에는 최대 3개 장소까지만 저장할 수 있습니다."
+            );
+        }
+
+        addPlaces(course, region, request.places());
+
+        return getCourseResponse(course);
+    }
+
+    @Transactional(readOnly = true)
+    public SelectedCourseResponse getActiveCourse(Long userId) {
+        Course course = findActiveCourse(userId);
+        return getCourseResponse(course);
+    }
+
+    private void inactiveActiveCourses(Long userId) {
+        List<Course> activeCourses = courseRepository
+                .findAllByUserIdAndStatus(userId, CourseStatus.ACTIVE);
+
+        activeCourses.forEach(Course::inactive);
+    }
+
+    private void addPlaces(
+            Course course,
+            Region region,
+            List<CoursePlaceSaveRequest> requests
+    ) {
+        validateDuplicateCategoryInRequest(requests);
+
+        int nextSequence = coursePlaceRepository.countByCourseId(
+                course.getId()
+        ) + 1;
+
+        for (CoursePlaceSaveRequest request : requests) {
+            Place place = resolvePlace(region, request);
+
+            validateCoursePlace(course, place);
+
+            CoursePlace coursePlace = CoursePlace.create(
+                    course,
+                    place,
+                    nextSequence++
+            );
+
+            coursePlaceRepository.save(coursePlace);
+        }
+    }
+
+    private Place resolvePlace(
+            Region region,
+            CoursePlaceSaveRequest request
+    ) {
+        if (request.placeId() != null) {
+            Place place = placeRepository.findById(request.placeId())
+                    .orElseThrow(PlaceNotFoundException::new);
+
+            validatePlaceRegion(region, place);
+
+            return place;
+        }
+
+        return resolveExternalPlace(region, request);
+    }
+
+    private Place resolveExternalPlace(
+            Region region,
+            CoursePlaceSaveRequest request
+    ) {
+        Place tourApiPlace = findOrCreateTourApiPlace(region, request);
+
+        if (tourApiPlace != null) {
+            return tourApiPlace;
+        }
+
+        return findOrCreateKakaoPlace(region, request);
+    }
+
+    private Place findOrCreateTourApiPlace(
+            Region region,
+            CoursePlaceSaveRequest request
+    ) {
+        if (isTourApiRequest(request)
+                && hasText(request.externalPlaceId())) {
+            return placeRepository.findByTourContentId(
+                            request.externalPlaceId()
+                    )
+                    .orElseGet(() -> createTourApiPlaceByContentId(
+                            region,
+                            request.externalPlaceId()
+                    ));
+        }
+
+        List<TourApiPlaceItem> items =
+                tourApiPlaceClient.searchPlacesByKeyword(
+                        request.title(),
+                        region.getLdongRegnCd(),
+                        region.getLdongSignguCd()
+                );
+
+        return items.stream()
+                .filter(item -> isSamePlace(item, request))
+                .findFirst()
+                .map(item -> placeRepository.findByTourContentId(
+                                item.contentId()
+                        )
+                        .orElseGet(() -> createTourApiPlace(region, item)))
+                .orElse(null);
+    }
+
+    private Place createTourApiPlaceByContentId(
+            Region region,
+            String contentId
+    ) {
+        TourApiPlaceItem item = tourApiPlaceClient.getPlaceDetail(contentId);
+
+        if (item == null) {
+            return null;
+        }
+
+        return createTourApiPlace(region, item);
+    }
+
+    private Place createTourApiPlace(
+            Region region,
+            TourApiPlaceItem item
+    ) {
+        PlaceCategoryGroup categoryGroup = PlaceCategoryMapper.toGroup(
+                item.lclsSystm1(),
+                item.lclsSystm3()
+        );
+
+        PlaceCategoryDetail categoryDetail = PlaceCategoryMapper.toDetail(
+                item.lclsSystm1(),
+                item.lclsSystm3()
+        );
+
+        Place place = Place.create(
+                region,
+                item.contentId(),
+                null,
+                item.title(),
+                item.address(),
+                toBigDecimal(item.latitude()),
+                toBigDecimal(item.longitude()),
+                item.firstImageUrl(),
+                item.lDongRegnCd(),
+                item.lDongSignguCd(),
+                item.lclsSystm1(),
+                item.lclsSystm2(),
+                item.lclsSystm3(),
+                categoryGroup,
+                categoryDetail,
+                false,
+                PlaceSource.TOUR_API
+        );
+
+        return placeRepository.save(place);
+    }
+
+    private Place findOrCreateKakaoPlace(
+            Region region,
+            CoursePlaceSaveRequest request
+    ) {
+        if (!hasText(request.externalPlaceId())) {
+            throw new IllegalArgumentException(
+                    "외부 후보 장소 저장 시 externalPlaceId는 필수입니다."
+            );
+        }
+
+        return placeRepository.findByKakaoPlaceId(request.externalPlaceId())
+                .orElseGet(() -> createKakaoPlace(region, request));
+    }
+
+    private Place createKakaoPlace(
+            Region region,
+            CoursePlaceSaveRequest request
+    ) {
+        PlaceCategoryGroup categoryGroup = toCategoryGroup(
+                request.categoryGroup()
+        );
+
+        PlaceCategoryDetail categoryDetail = toCategoryDetail(
+                request.categoryDetail(),
+                categoryGroup
+        );
+
+        Place place = Place.create(
+                region,
+                null,
+                request.externalPlaceId(),
+                request.title(),
+                request.address(),
+                request.latitude(),
+                request.longitude(),
+                null,
+                region.getLdongRegnCd(),
+                region.getLdongSignguCd(),
+                null,
+                null,
+                null,
+                categoryGroup,
+                categoryDetail,
+                false,
+                PlaceSource.KAKAO_LOCAL
+        );
+
+        return placeRepository.save(place);
+    }
+
+    private void validateCoursePlace(
+            Course course,
+            Place place
+    ) {
+        if (coursePlaceRepository.existsByCourseIdAndPlaceId(
+                course.getId(),
+                place.getId()
+        )) {
+            throw new IllegalArgumentException(
+                    "이미 ACTIVE 코스에 저장된 장소입니다."
+            );
+        }
+
+        if (coursePlaceRepository.existsByCourseIdAndCategoryGroup(
+                course.getId(),
+                place.getCategoryGroup()
+        )) {
+            throw new IllegalArgumentException(
+                    "이미 ACTIVE 코스에 저장된 장소 유형입니다."
+            );
+        }
+    }
+
+    private void validateDuplicateCategoryInRequest(
+            List<CoursePlaceSaveRequest> requests
+    ) {
+        Set<PlaceCategoryGroup> categoryGroups = new HashSet<>();
+
+        for (CoursePlaceSaveRequest request : requests) {
+            PlaceCategoryGroup categoryGroup = toCategoryGroup(
+                    request.categoryGroup()
+            );
+
+            if (!categoryGroups.add(categoryGroup)) {
+                throw new IllegalArgumentException(
+                        "한 번의 요청에 동일한 장소 유형을 중복 저장할 수 없습니다."
+                );
+            }
+        }
+    }
+
+    private void validatePlaceRequestSize(
+            List<CoursePlaceSaveRequest> places
+    ) {
+        if (places == null || places.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "코스 장소는 1개 이상 선택해야 합니다."
+            );
+        }
+
+        if (places.size() > MAX_COURSE_PLACE_COUNT) {
+            throw new IllegalArgumentException(
+                    "코스 장소는 최대 3개까지 선택할 수 있습니다."
+            );
+        }
+    }
+
+    private void validatePlaceRegion(
+            Region region,
+            Place place
+    ) {
+        if (!place.getRegion().getId().equals(region.getId())) {
+            throw new IllegalArgumentException(
+                    "선택한 장소가 코스 지역과 일치하지 않습니다."
+            );
+        }
+    }
+
+    private SelectedCourseResponse getCourseResponse(Course course) {
+        List<CoursePlace> coursePlaces = coursePlaceRepository
+                .findByCourseIdOrderBySequenceAsc(course.getId());
+
+        return SelectedCourseResponse.of(course, coursePlaces);
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "사용자를 찾을 수 없습니다."
+                ));
+    }
+
+    private Region findRegion(Long regionId) {
+        return regionRepository.findById(regionId)
+                .orElseThrow(RegionNotFoundException::new);
+    }
+
+    private Course findActiveCourse(Long userId) {
+        return courseRepository.findByUserIdAndStatus(
+                        userId,
+                        CourseStatus.ACTIVE
+                )
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "ACTIVE 코스가 없습니다."
+                ));
+    }
+
+    private boolean isTourApiRequest(CoursePlaceSaveRequest request) {
+        return PlaceSource.TOUR_API.name().equals(request.source());
+    }
+
+    private boolean isSamePlace(
+            TourApiPlaceItem item,
+            CoursePlaceSaveRequest request
+    ) {
+        String itemTitle = normalize(item.title());
+        String requestTitle = normalize(request.title());
+
+        if (!itemTitle.equals(requestTitle)) {
+            return false;
+        }
+
+        if (!hasText(request.address())) {
+            return true;
+        }
+
+        String itemAddress = normalize(item.address());
+        String requestAddress = normalize(request.address());
+
+        return itemAddress.contains(requestAddress)
+                || requestAddress.contains(itemAddress);
+    }
+
+    private PlaceCategoryGroup toCategoryGroup(String value) {
+        try {
+            return PlaceCategoryGroup.valueOf(value);
+        } catch (RuntimeException exception) {
+            throw new IllegalArgumentException(
+                    "지원하지 않는 장소 유형입니다."
+            );
+        }
+    }
+
+    private PlaceCategoryDetail toCategoryDetail(
+            String value,
+            PlaceCategoryGroup categoryGroup
+    ) {
+        if (!hasText(value)) {
+            return getDefaultCategoryDetail(categoryGroup);
+        }
+
+        try {
+            return PlaceCategoryDetail.valueOf(value);
+        } catch (RuntimeException exception) {
+            return getDefaultCategoryDetail(categoryGroup);
+        }
+    }
+
+    private PlaceCategoryDetail getDefaultCategoryDetail(
+            PlaceCategoryGroup categoryGroup
+    ) {
+        return switch (categoryGroup) {
+            case TOURISM -> PlaceCategoryDetail.EXPERIENCE;
+            case FOOD -> PlaceCategoryDetail.RESTAURANT;
+            case CAFE_DESSERT -> PlaceCategoryDetail.CAFE;
+        };
+    }
+
+    private BigDecimal toBigDecimal(String value) {
+        if (!hasText(value)) {
+            return null;
+        }
+
+        try {
+            return new BigDecimal(value);
+        } catch (NumberFormatException exception) {
+            return null;
+        }
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value.replaceAll("\\s+", "")
+                .toLowerCase();
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/src/main/java/com/chaerok/backend/course/service/CourseCommandService.java
+++ b/src/main/java/com/chaerok/backend/course/service/CourseCommandService.java
@@ -153,10 +153,14 @@ public class CourseCommandService {
         Place tourApiPlace = findOrCreateTourApiPlace(region, request);
 
         if (tourApiPlace != null) {
+            validatePlaceRegion(region, tourApiPlace);
             return tourApiPlace;
         }
 
-        return findOrCreateKakaoPlace(region, request);
+        Place kakaoPlace = findOrCreateKakaoPlace(region, request);
+        validatePlaceRegion(region, kakaoPlace);
+
+        return kakaoPlace;
     }
 
     private Place findOrCreateTourApiPlace(
@@ -168,7 +172,7 @@ public class CourseCommandService {
             return placeRepository.findByTourContentId(
                             request.externalPlaceId()
                     )
-                    .orElseGet(() -> createTourApiPlaceByContentId(
+                    .orElseGet(() -> createTourApiPlaceByContentIdOrThrow(
                             region,
                             request.externalPlaceId()
                     ));
@@ -191,15 +195,19 @@ public class CourseCommandService {
                 .orElse(null);
     }
 
-    private Place createTourApiPlaceByContentId(
+    private Place createTourApiPlaceByContentIdOrThrow(
             Region region,
             String contentId
     ) {
         TourApiPlaceItem item = tourApiPlaceClient.getPlaceDetail(contentId);
 
         if (item == null) {
-            return null;
+            throw new IllegalArgumentException(
+                    "TourAPI 장소 정보를 찾을 수 없습니다."
+            );
         }
+
+        validateTourApiItemRegion(region, item);
 
         return createTourApiPlace(region, item);
     }
@@ -208,6 +216,8 @@ public class CourseCommandService {
             Region region,
             TourApiPlaceItem item
     ) {
+        validateTourApiItemRegion(region, item);
+
         PlaceCategoryGroup categoryGroup = PlaceCategoryMapper.toGroup(
                 item.lclsSystm1(),
                 item.lclsSystm3()
@@ -239,6 +249,18 @@ public class CourseCommandService {
         );
 
         return placeRepository.save(place);
+    }
+
+    private void validateTourApiItemRegion(
+            Region region,
+            TourApiPlaceItem item
+    ) {
+        if (!region.getLdongRegnCd().equals(item.lDongRegnCd())
+                || !region.getLdongSignguCd().equals(item.lDongSignguCd())) {
+            throw new IllegalArgumentException(
+                    "TourAPI 장소가 코스 지역과 일치하지 않습니다."
+            );
+        }
     }
 
     private Place findOrCreateKakaoPlace(

--- a/src/main/java/com/chaerok/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/chaerok/backend/global/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.http.HttpMethod;
 
 @Configuration
 @RequiredArgsConstructor
@@ -44,11 +45,15 @@ public class SecurityConfig {
                                 "/api/health",
                                 "/api/auth/**",
                                 "/api/places/**",
-                                "/api/courses/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**",
                                 "/error"
+                        ).permitAll()
+
+                        .requestMatchers(
+                                HttpMethod.GET,
+                                "/api/courses/recommend"
                         ).permitAll()
 
                         .requestMatchers("/api/admin/**")

--- a/src/main/java/com/chaerok/backend/place/repository/PlaceRepository.java
+++ b/src/main/java/com/chaerok/backend/place/repository/PlaceRepository.java
@@ -14,5 +14,7 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 
     Optional<Place> findByTourContentId(String tourContentId);
 
+    Optional<Place> findByKakaoPlaceId(String kakaoPlaceId);
+
     boolean existsByTourContentId(String tourContentId);
 }

--- a/src/main/resources/db/migration/V9__create_courses_and_course_places.sql
+++ b/src/main/resources/db/migration/V9__create_courses_and_course_places.sql
@@ -1,0 +1,51 @@
+create table courses (
+                         id bigserial primary key,
+                         user_id bigint not null,
+                         region_id bigint not null,
+                         title varchar(255) not null,
+                         status varchar(30) not null,
+                         created_at timestamp not null,
+                         updated_at timestamp not null,
+
+                         constraint fk_courses_user
+                             foreign key (user_id)
+                                 references users(id),
+
+                         constraint fk_courses_region
+                             foreign key (region_id)
+                                 references regions(id)
+);
+
+create table course_places (
+                               id bigserial primary key,
+                               course_id bigint not null,
+                               place_id bigint not null,
+                               sequence integer not null,
+                               category_group varchar(30) not null,
+                               category_detail varchar(30),
+                               created_at timestamp not null,
+
+                               constraint fk_course_places_course
+                                   foreign key (course_id)
+                                       references courses(id)
+                                       on delete cascade,
+
+                               constraint fk_course_places_place
+                                   foreign key (place_id)
+                                       references places(id),
+
+                               constraint uk_course_places_course_place
+                                   unique (course_id, place_id),
+
+                               constraint uk_course_places_course_category_group
+                                   unique (course_id, category_group),
+
+                               constraint uk_course_places_course_sequence
+                                   unique (course_id, sequence)
+);
+
+create index idx_courses_user_status
+    on courses(user_id, status);
+
+create index idx_course_places_course_id
+    on course_places(course_id);

--- a/src/main/resources/db/migration/V9__create_courses_and_course_places.sql
+++ b/src/main/resources/db/migration/V9__create_courses_and_course_places.sql
@@ -47,5 +47,9 @@ create table course_places (
 create index idx_courses_user_status
     on courses(user_id, status);
 
+create unique index uk_courses_user_active
+    on courses(user_id)
+    where status = 'ACTIVE';
+
 create index idx_course_places_course_id
     on course_places(course_id);


### PR DESCRIPTION
## ✨ 변경 사항

- 사용자 선택 코스 등록 API 구현
- ACTIVE 코스 장소 추가 API 구현
- 로그인 사용자 기준 ACTIVE 코스 조회 API 구현
- Course, CoursePlace 저장 구조 추가
- 선택 장소 1~3개 저장 및 최대 3개 제한 처리
- 동일 장소 및 동일 장소 유형 중복 저장 제한 처리
- 외부 후보 장소 저장 시 TourAPI 우선 매칭 후 Kakao Local 저장 처리
- 새로 저장되는 장소 `is_representative = false` 처리
- 추천 코스 응답에 장소 좌표 정보 추가
- Course 저장 API 인증 적용 및 추천 조회 API 공개 유지

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [x] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #32 

## 🧩 API / DB 변경 사항

### API 추가

- `POST /api/courses`
- `POST /api/courses/active/places`
- `GET /api/courses/active`

### API 변경

- `GET /api/courses/recommend`
  - 추천 장소 응답에 `latitude`, `longitude` 추가

### DB 추가

- `courses`
- `course_places`

### DB 변경

- 선택한 외부 후보 장소가 `places`에 없을 경우 신규 저장
- 신규 저장 장소는 출처와 관계없이 `is_representative = false`
- Kakao Local 장소 중복 저장 방지를 위해 `kakao_place_id` 기준 조회 추가

## ✅ 테스트

- [x] 서버 실행 확인
- [x] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- Course 2차는 필름 롤과 직접 연결하지 않음
- 선택 코스는 추후 활성 필름 롤과 연결될 임시 여행 코스 성격으로 관리
- `film_roll_id`는 이번 단계에서 추가하지 않음
- 지역 이탈 후 코스 만료/삭제 처리는 FilmRoll 연동 단계에서 구현 예정
- `GET /api/courses/recommend`는 공개 API로 유지하고, 코스 저장/조회 API는 JWT 인증 필요
- 로컬 테스트용 DevTokenController와 `/api/dev/**` 설정은 커밋 전 제거 완료
- `./gradlew test` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 지역·제목으로 코스를 생성하고, 활성 코스에 장소를 추가하며, 활성 코스를 조회할 수 있습니다.
  * 활성 코스 응답에 포함된 장소의 위도·경도 정보가 표시됩니다.
* **유효성 검사**
  * 필수 입력값과 장소 개수(1~3개)를 검증하고, 코스 내 장소/장소 유형 중복을 방지합니다.
* **보안**
  * 코스 생성·장소 추가·활성 코스 조회는 인증이 필요하도록 변경했으며, 추천 조회만 공개로 설정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->