### PR TITLE
feat(heritage): 역사 테마 대상 장소 판별 API 구현

### DIFF
--- a/src/main/java/com/chaerok/backend/heritage/controller/HeritageController.java
+++ b/src/main/java/com/chaerok/backend/heritage/controller/HeritageController.java
@@ -1,0 +1,32 @@
+package com.chaerok.backend.heritage.controller;
+
+import com.chaerok.backend.heritage.dto.HeritagePlaceResponse;
+import com.chaerok.backend.heritage.service.HeritageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Heritage", description = "역사 테마 장소 판별 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/heritage")
+public class HeritageController {
+
+    private final HeritageService heritageService;
+
+    @Operation(
+            summary = "역사 테마 대상 장소 조회",
+            description = "장소 ID를 기준으로 TourAPI를 실시간 조회하여 역사 테마 대상 여부를 반환한다."
+    )
+    @GetMapping("/places/{placeId}")
+    public ResponseEntity<HeritagePlaceResponse> getHeritagePlace(
+            @PathVariable Long placeId
+    ) {
+        return ResponseEntity.ok(heritageService.getHeritagePlace(placeId));
+    }
+}

--- a/src/main/java/com/chaerok/backend/heritage/dto/HeritagePlaceResponse.java
+++ b/src/main/java/com/chaerok/backend/heritage/dto/HeritagePlaceResponse.java
@@ -1,0 +1,39 @@
+package com.chaerok.backend.heritage.dto;
+
+import com.chaerok.backend.place.external.TourApiPlaceItem;
+
+public record HeritagePlaceResponse(
+        Long placeId,
+        String contentId,
+        String title,
+        String address,
+        String regionName,
+        boolean heritage,
+        String lclsSystm1,
+        String lclsSystm2,
+        String lclsSystm3,
+        String overview,
+        String imageUrl
+) {
+
+    public static HeritagePlaceResponse of(
+            Long placeId,
+            String regionName,
+            boolean heritage,
+            TourApiPlaceItem item
+    ) {
+        return new HeritagePlaceResponse(
+                placeId,
+                item.contentId(),
+                item.title(),
+                item.address(),
+                regionName,
+                heritage,
+                item.lclsSystm1(),
+                item.lclsSystm2(),
+                item.lclsSystm3(),
+                item.overview(),
+                item.firstImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/chaerok/backend/heritage/service/HeritageService.java
+++ b/src/main/java/com/chaerok/backend/heritage/service/HeritageService.java
@@ -1,0 +1,58 @@
+package com.chaerok.backend.heritage.service;
+
+import com.chaerok.backend.heritage.dto.HeritagePlaceResponse;
+import com.chaerok.backend.place.entity.Place;
+import com.chaerok.backend.place.external.TourApiPlaceClient;
+import com.chaerok.backend.place.external.TourApiPlaceItem;
+import com.chaerok.backend.place.repository.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HeritageService {
+
+    private static final String GUNGNAMJI_CONTENT_ID = "125984";
+
+    private final PlaceRepository placeRepository;
+    private final TourApiPlaceClient tourApiPlaceClient;
+
+    public HeritagePlaceResponse getHeritagePlace(Long placeId) {
+        Place place = placeRepository.findById(placeId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 장소입니다."));
+
+        String contentId = place.getTourContentId();
+
+        if (contentId == null || contentId.isBlank()) {
+            throw new IllegalArgumentException("TourAPI 장소가 아닙니다.");
+        }
+
+        TourApiPlaceItem item = tourApiPlaceClient.getPlaceDetail(contentId);
+
+        if (item == null) {
+            throw new IllegalStateException("TourAPI 장소 정보를 조회할 수 없습니다.");
+        }
+
+        boolean heritage = isHeritage(item);
+
+        String regionName = place.getRegion().getProvinceName()
+                + " "
+                + place.getRegion().getCityCountyName();
+
+        return HeritagePlaceResponse.of(
+                place.getId(),
+                regionName,
+                heritage,
+                item
+        );
+    }
+
+    private boolean isHeritage(TourApiPlaceItem item) {
+        boolean heritageCategory = "HS".equals(item.lclsSystm1());
+        boolean heritageException = GUNGNAMJI_CONTENT_ID.equals(item.contentId());
+
+        return heritageCategory || heritageException;
+    }
+}

--- a/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
+++ b/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
@@ -152,11 +152,8 @@ public class TourApiPlaceClient {
                             .queryParam("MobileApp", "Chaerok")
                             .queryParam("_type", "json")
                             .queryParam("contentId", contentId)
-                            .queryParam("defaultYN", "Y")
-                            .queryParam("firstImageYN", "Y")
-                            .queryParam("addrinfoYN", "Y")
-                            .queryParam("mapinfoYN", "Y")
-                            .queryParam("overviewYN", "Y")
+                            .queryParam("numOfRows", 10)
+                            .queryParam("pageNo", 1)
                             .build())
                     .retrieve()
                     .bodyToMono(TourApiPlaceResponse.class)
@@ -168,24 +165,41 @@ public class TourApiPlaceClient {
             }
 
             if (!response.isSuccess()) {
-                log.warn("TourAPI detailCommon2 failed. contentId={}", contentId);
+                log.warn(
+                        "TourAPI detailCommon2 failed. contentId={}, resultCode={}, resultMsg={}",
+                        contentId
+                );
                 return null;
             }
 
             return response.getItems().stream()
                     .findFirst()
                     .orElse(null);
+
         } catch (WebClientResponseException e) {
-            log.warn("TourAPI detailCommon2 response error. contentId={}, status={}, body={}",
-                    contentId, e.getStatusCode(), e.getResponseBodyAsString());
+            log.warn(
+                    "TourAPI detailCommon2 response error. contentId={}, status={}, body={}",
+                    contentId,
+                    e.getStatusCode(),
+                    e.getResponseBodyAsString()
+            );
             return null;
+
         } catch (WebClientRequestException e) {
-            log.warn("TourAPI detailCommon2 request error. contentId={}, message={}",
-                    contentId, e.getMessage());
+            log.warn(
+                    "TourAPI detailCommon2 request error. contentId={}, message={}",
+                    contentId,
+                    e.getMessage()
+            );
             return null;
+
         } catch (RuntimeException e) {
-            log.error("TourAPI detailCommon2 unexpected error. contentId={}, message={}",
-                    contentId, e.getMessage(), e);
+            log.error(
+                    "TourAPI detailCommon2 unexpected error. contentId={}, message={}",
+                    contentId,
+                    e.getMessage(),
+                    e
+            );
             return null;
         }
     }


### PR DESCRIPTION
## ✨ 변경 사항

- `placeId` 기반 Heritage 조회 API 구현
- TourAPI `detailCommon2` 실시간 호출을 통한 관광지 상세 및 분류체계 조회
- 관광 자원 대분류 `HS` 기반 역사 테마 대상 판별
- 역사 유적 성격을 가진 서동공원과 궁남지 정책 예외 처리
- 장소명, 주소, 지역명, 분류체계 코드, 소개 문구 및 대표 이미지 응답
- TourAPI 빈 응답 및 호출 실패 처리
- 최신 TourAPI 명세에 맞게 `detailCommon2` 요청 파라미터 정비
- Swagger 문서화

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #34 

## 🧩 API / DB 변경 사항

- API 추가: `GET /api/heritage/places/{placeId}`
- DB 변경 없음
- Storage 변경 없음
- `places` 테이블의 `tour_content_id`와 지역 정보를 TourAPI 실시간 조회 연결에 활용
- Heritage 여부 별도 컬럼 및 테이블 미추가

## ✅ 테스트

- [x] 서버 실행 확인
- [x] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

### 수동 테스트 결과

- 공주 공산성: `HS` 분류, `heritage=true`
- 제민천: `NA` 분류, `heritage=false`
- 향천사: `HS` 분류, `heritage=true`
- 국립공주박물관: `VE` 분류, `heritage=false`
- 서동공원과 궁남지: `NA` 분류 및 정책 예외, `heritage=true`
- TourAPI 실시간 상세 조회 및 소개 문구·대표 이미지 반환 확인

## 💬 참고 사항

- Heritage는 유적지 전용 모드 활성화 여부를 판별하는 기능이며 Odii 오디오 조회 기능과 분리함
- Heritage 대상 장소는 이후 Odii 콘텐츠를 별도로 조회하며, 오디오가 없으면 TourAPI 소개 문구를 대체 정보로 활용함
- 유적지 방문 기록 반영과 역사 테마 엽서 생성은 Backend 2 담당 범위임
- 사용자 GPS 좌표는 Heritage API에서 전달받지 않음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 장소 ID로 문화유산 장소의 상세 정보를 조회할 수 있는 API를 추가했습니다.
  - 장소명, 주소, 지역, 문화유산 여부, 설명, 이미지 등 상세 정보를 제공합니다.
  - 관광지 상세 정보 조회 시 필요한 데이터가 보다 안정적으로 제공됩니다.

- **개선 사항**
  - 외부 관광 정보 조회 요청을 조정해 장소 상세 데이터 처리와 오류 기록을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->