### PR TITLE
feat(odii): 유적지 오디오 가이드 조회 API 구현

### DIFF
--- a/src/main/java/com/chaerok/backend/odii/config/OdiiProperties.java
+++ b/src/main/java/com/chaerok/backend/odii/config/OdiiProperties.java
@@ -1,0 +1,19 @@
+package com.chaerok.backend.odii.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "external.odii")
+public class OdiiProperties {
+
+    private String baseUrl;
+    private String serviceKey;
+    private String mobileOs;
+    private String mobileApp;
+    private String languageCode;
+}

--- a/src/main/java/com/chaerok/backend/odii/controller/OdiiController.java
+++ b/src/main/java/com/chaerok/backend/odii/controller/OdiiController.java
@@ -1,0 +1,46 @@
+package com.chaerok.backend.odii.controller;
+
+import com.chaerok.backend.odii.dto.OdiiGuideResponse;
+import com.chaerok.backend.odii.service.OdiiService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "Odii",
+        description = "유적지 대표 오디오 가이드 조회 API"
+)
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/odii")
+public class OdiiController {
+
+    private final OdiiService odiiService;
+
+    @Operation(
+            summary = "유적지 대표 오디오 가이드 조회",
+            description = """
+                    장소의 Heritage 대상 여부를 확인한 뒤 Odii API를 실시간으로 조회합니다.
+                    재생 가능한 오디오가 있으면 대표 가이드 한 개를 반환하고,
+                    없으면 한국관광공사 TourAPI 소개 문구를 대체 정보로 반환합니다.
+                    """
+    )
+    @GetMapping("/places/{placeId}")
+    public ResponseEntity<OdiiGuideResponse> getAudioGuide(
+            @Parameter(
+                    description = "장소 ID",
+                    example = "1"
+            )
+            @PathVariable Long placeId
+    ) {
+        return ResponseEntity.ok(
+                odiiService.getAudioGuide(placeId)
+        );
+    }
+}

--- a/src/main/java/com/chaerok/backend/odii/dto/OdiiGuideResponse.java
+++ b/src/main/java/com/chaerok/backend/odii/dto/OdiiGuideResponse.java
@@ -1,0 +1,84 @@
+package com.chaerok.backend.odii.dto;
+
+import com.chaerok.backend.odii.external.OdiiStoryItem;
+
+public record OdiiGuideResponse(
+        Long placeId,
+        String placeTitle,
+        boolean heritage,
+        boolean audioAvailable,
+        AudioGuide audioGuide,
+        String guideScript,
+        String fallbackOverview
+) {
+
+    public static OdiiGuideResponse withAudio(
+            Long placeId,
+            String placeTitle,
+            OdiiStoryItem story
+    ) {
+        return new OdiiGuideResponse(
+                placeId,
+                placeTitle,
+                true,
+                true,
+                AudioGuide.from(story),
+                story.script(),
+                null
+        );
+    }
+
+    public static OdiiGuideResponse withScript(
+            Long placeId,
+            String placeTitle,
+            OdiiStoryItem story
+    ) {
+        return new OdiiGuideResponse(
+                placeId,
+                placeTitle,
+                true,
+                false,
+                null,
+                story.script(),
+                null
+        );
+    }
+
+    public static OdiiGuideResponse withoutOdii(
+            Long placeId,
+            String placeTitle,
+            boolean heritage,
+            String fallbackOverview
+    ) {
+        return new OdiiGuideResponse(
+                placeId,
+                placeTitle,
+                heritage,
+                false,
+                null,
+                null,
+                fallbackOverview
+        );
+    }
+
+    public record AudioGuide(
+            String storyId,
+            String title,
+            String audioTitle,
+            Integer playTime,
+            String audioUrl,
+            String imageUrl
+    ) {
+
+        public static AudioGuide from(OdiiStoryItem story) {
+            return new AudioGuide(
+                    story.stid(),
+                    story.title(),
+                    story.audioTitle(),
+                    story.playTime(),
+                    story.audioUrl(),
+                    story.imageUrl()
+            );
+        }
+    }
+}

--- a/src/main/java/com/chaerok/backend/odii/external/OdiiApiClient.java
+++ b/src/main/java/com/chaerok/backend/odii/external/OdiiApiClient.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -18,6 +19,12 @@ public class OdiiApiClient {
     private static final int DEFAULT_NUM_OF_ROWS = 20;
     private static final String RESPONSE_TYPE = "json";
     private static final String SUCCESS_CODE = "0000";
+
+    /*
+     * 공공데이터 API 응답 지연을 고려해 15초로 설정한다.
+     * 제한 시간을 초과하면 예외를 처리하고 빈 목록을 반환한다.
+     */
+    private static final Duration API_TIMEOUT = Duration.ofSeconds(15);
 
     private final WebClient webClient;
     private final OdiiProperties properties;
@@ -55,16 +62,25 @@ public class OdiiApiClient {
                             .build())
                     .retrieve()
                     .bodyToMono(JsonNode.class)
+                    .timeout(API_TIMEOUT)
                     .block();
 
             if (!isSuccess(root)) {
-                log.warn("Odii themeSearchList 호출 실패. keyword={}", keyword);
+                logApiFailure(
+                        "themeSearchList",
+                        root,
+                        "keyword=" + keyword
+                );
+
                 return Collections.emptyList();
             }
 
             JsonNode itemNode = getItemNode(root);
 
-            if (itemNode == null || itemNode.isMissingNode() || itemNode.isNull()) {
+            if (itemNode == null
+                    || itemNode.isMissingNode()
+                    || itemNode.isNull()) {
+
                 return Collections.emptyList();
             }
 
@@ -83,8 +99,9 @@ public class OdiiApiClient {
             return items;
         } catch (Exception e) {
             log.warn(
-                    "Odii themeSearchList 호출 중 예외 발생. keyword={}, message={}",
+                    "Odii themeSearchList 호출 중 예외 발생. keyword={}, exception={}, message={}",
                     keyword,
+                    e.getClass().getSimpleName(),
                     e.getMessage()
             );
 
@@ -100,7 +117,11 @@ public class OdiiApiClient {
      * @return 관광지 이야기 목록
      */
     public List<OdiiStoryItem> getStories(String tid, String tlid) {
-        if (tid == null || tid.isBlank() || tlid == null || tlid.isBlank()) {
+        if (tid == null
+                || tid.isBlank()
+                || tlid == null
+                || tlid.isBlank()) {
+
             return Collections.emptyList();
         }
 
@@ -120,13 +141,14 @@ public class OdiiApiClient {
                             .build())
                     .retrieve()
                     .bodyToMono(JsonNode.class)
+                    .timeout(API_TIMEOUT)
                     .block();
 
             if (!isSuccess(root)) {
-                log.warn(
-                        "Odii storyBasedList 호출 실패. tid={}, tlid={}",
-                        tid,
-                        tlid
+                logApiFailure(
+                        "storyBasedList",
+                        root,
+                        "tid=" + tid + ", tlid=" + tlid
                 );
 
                 return Collections.emptyList();
@@ -134,7 +156,10 @@ public class OdiiApiClient {
 
             JsonNode itemNode = getItemNode(root);
 
-            if (itemNode == null || itemNode.isMissingNode() || itemNode.isNull()) {
+            if (itemNode == null
+                    || itemNode.isMissingNode()
+                    || itemNode.isNull()) {
+
                 return Collections.emptyList();
             }
 
@@ -161,9 +186,10 @@ public class OdiiApiClient {
             return stories;
         } catch (Exception e) {
             log.warn(
-                    "Odii storyBasedList 호출 중 예외 발생. tid={}, tlid={}, message={}",
+                    "Odii storyBasedList 호출 중 예외 발생. tid={}, tlid={}, exception={}, message={}",
                     tid,
                     tlid,
+                    e.getClass().getSimpleName(),
                     e.getMessage()
             );
 
@@ -239,5 +265,39 @@ public class OdiiApiClient {
 
             return null;
         }
+    }
+
+    private void logApiFailure(
+            String operation,
+            JsonNode root,
+            String requestContext
+    ) {
+        if (root == null) {
+            log.warn(
+                    "Odii API 응답이 없습니다. operation={}, request={}",
+                    operation,
+                    requestContext
+            );
+
+            return;
+        }
+
+        String resultCode = root.path("response")
+                .path("header")
+                .path("resultCode")
+                .asText();
+
+        String resultMessage = root.path("response")
+                .path("header")
+                .path("resultMsg")
+                .asText();
+
+        log.warn(
+                "Odii API 호출 실패. operation={}, request={}, resultCode={}, resultMessage={}",
+                operation,
+                requestContext,
+                resultCode,
+                resultMessage
+        );
     }
 }

--- a/src/main/java/com/chaerok/backend/odii/external/OdiiApiClient.java
+++ b/src/main/java/com/chaerok/backend/odii/external/OdiiApiClient.java
@@ -1,0 +1,243 @@
+package com.chaerok.backend.odii.external;
+
+import com.chaerok.backend.odii.config.OdiiProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Component
+public class OdiiApiClient {
+
+    private static final int DEFAULT_PAGE_NO = 1;
+    private static final int DEFAULT_NUM_OF_ROWS = 20;
+    private static final String RESPONSE_TYPE = "json";
+    private static final String SUCCESS_CODE = "0000";
+
+    private final WebClient webClient;
+    private final OdiiProperties properties;
+
+    public OdiiApiClient(OdiiProperties properties) {
+        this.properties = properties;
+        this.webClient = WebClient.builder()
+                .baseUrl(properties.getBaseUrl())
+                .build();
+    }
+
+    /**
+     * 관광지 키워드 검색
+     *
+     * @param keyword Odii 관광지 검색 키워드
+     * @return 검색된 관광지 목록
+     */
+    public List<OdiiThemeItem> searchThemes(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        try {
+            JsonNode root = webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/themeSearchList")
+                            .queryParam("numOfRows", DEFAULT_NUM_OF_ROWS)
+                            .queryParam("pageNo", DEFAULT_PAGE_NO)
+                            .queryParam("MobileOS", properties.getMobileOs())
+                            .queryParam("MobileApp", properties.getMobileApp())
+                            .queryParam("serviceKey", properties.getServiceKey())
+                            .queryParam("_type", RESPONSE_TYPE)
+                            .queryParam("keyword", keyword)
+                            .queryParam("langCode", properties.getLanguageCode())
+                            .build())
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (!isSuccess(root)) {
+                log.warn("Odii themeSearchList 호출 실패. keyword={}", keyword);
+                return Collections.emptyList();
+            }
+
+            JsonNode itemNode = getItemNode(root);
+
+            if (itemNode == null || itemNode.isMissingNode() || itemNode.isNull()) {
+                return Collections.emptyList();
+            }
+
+            List<OdiiThemeItem> items = new ArrayList<>();
+
+            for (JsonNode node : normalizeItems(itemNode)) {
+                items.add(new OdiiThemeItem(
+                        text(node, "tid"),
+                        text(node, "tlid"),
+                        text(node, "title"),
+                        text(node, "mapX"),
+                        text(node, "mapY")
+                ));
+            }
+
+            return items;
+        } catch (Exception e) {
+            log.warn(
+                    "Odii themeSearchList 호출 중 예외 발생. keyword={}, message={}",
+                    keyword,
+                    e.getMessage()
+            );
+
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * 관광지에 연결된 이야기 목록 조회
+     *
+     * @param tid  관광지 ID
+     * @param tlid 관광지 언어 ID
+     * @return 관광지 이야기 목록
+     */
+    public List<OdiiStoryItem> getStories(String tid, String tlid) {
+        if (tid == null || tid.isBlank() || tlid == null || tlid.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        try {
+            JsonNode root = webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/storyBasedList")
+                            .queryParam("numOfRows", DEFAULT_NUM_OF_ROWS)
+                            .queryParam("pageNo", DEFAULT_PAGE_NO)
+                            .queryParam("MobileOS", properties.getMobileOs())
+                            .queryParam("MobileApp", properties.getMobileApp())
+                            .queryParam("serviceKey", properties.getServiceKey())
+                            .queryParam("_type", RESPONSE_TYPE)
+                            .queryParam("langCode", properties.getLanguageCode())
+                            .queryParam("tid", tid)
+                            .queryParam("tlid", tlid)
+                            .build())
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            if (!isSuccess(root)) {
+                log.warn(
+                        "Odii storyBasedList 호출 실패. tid={}, tlid={}",
+                        tid,
+                        tlid
+                );
+
+                return Collections.emptyList();
+            }
+
+            JsonNode itemNode = getItemNode(root);
+
+            if (itemNode == null || itemNode.isMissingNode() || itemNode.isNull()) {
+                return Collections.emptyList();
+            }
+
+            List<OdiiStoryItem> stories = new ArrayList<>();
+
+            for (JsonNode node : normalizeItems(itemNode)) {
+                stories.add(new OdiiStoryItem(
+                        text(node, "tid"),
+                        text(node, "tlid"),
+                        text(node, "stid"),
+                        text(node, "stlid"),
+                        text(node, "title"),
+                        text(node, "mapX"),
+                        text(node, "mapY"),
+                        text(node, "audioTitle"),
+                        text(node, "script"),
+                        integer(node, "playTime"),
+                        text(node, "audioUrl"),
+                        text(node, "langCode"),
+                        text(node, "imageUrl")
+                ));
+            }
+
+            return stories;
+        } catch (Exception e) {
+            log.warn(
+                    "Odii storyBasedList 호출 중 예외 발생. tid={}, tlid={}, message={}",
+                    tid,
+                    tlid,
+                    e.getMessage()
+            );
+
+            return Collections.emptyList();
+        }
+    }
+
+    private boolean isSuccess(JsonNode root) {
+        if (root == null) {
+            return false;
+        }
+
+        String resultCode = root.path("response")
+                .path("header")
+                .path("resultCode")
+                .asText();
+
+        return SUCCESS_CODE.equals(resultCode);
+    }
+
+    private JsonNode getItemNode(JsonNode root) {
+        return root.path("response")
+                .path("body")
+                .path("items")
+                .path("item");
+    }
+
+    /**
+     * Odii 응답은 결과 개수에 따라 item이 배열 또는 단일 객체로 내려올 수 있어
+     * 항상 순회 가능한 목록으로 정규화한다.
+     */
+    private List<JsonNode> normalizeItems(JsonNode itemNode) {
+        if (itemNode.isArray()) {
+            List<JsonNode> items = new ArrayList<>();
+            itemNode.forEach(items::add);
+            return items;
+        }
+
+        if (itemNode.isObject()) {
+            return List.of(itemNode);
+        }
+
+        return Collections.emptyList();
+    }
+
+    private String text(JsonNode node, String fieldName) {
+        JsonNode value = node.get(fieldName);
+
+        if (value == null || value.isNull()) {
+            return null;
+        }
+
+        String text = value.asText();
+
+        return text.isBlank() ? null : text.trim();
+    }
+
+    private Integer integer(JsonNode node, String fieldName) {
+        String value = text(node, fieldName);
+
+        if (value == null) {
+            return null;
+        }
+
+        try {
+            return Integer.valueOf(value);
+        } catch (NumberFormatException e) {
+            log.debug(
+                    "Odii 숫자 필드 변환 실패. fieldName={}, value={}",
+                    fieldName,
+                    value
+            );
+
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/chaerok/backend/odii/external/OdiiStoryItem.java
+++ b/src/main/java/com/chaerok/backend/odii/external/OdiiStoryItem.java
@@ -1,0 +1,22 @@
+package com.chaerok.backend.odii.external;
+
+public record OdiiStoryItem(
+        String tid,
+        String tlid,
+        String stid,
+        String stlid,
+        String title,
+        String mapX,
+        String mapY,
+        String audioTitle,
+        String script,
+        Integer playTime,
+        String audioUrl,
+        String langCode,
+        String imageUrl
+) {
+
+    public boolean hasPlayableAudio() {
+        return audioUrl != null && !audioUrl.isBlank();
+    }
+}

--- a/src/main/java/com/chaerok/backend/odii/external/OdiiThemeItem.java
+++ b/src/main/java/com/chaerok/backend/odii/external/OdiiThemeItem.java
@@ -1,0 +1,10 @@
+package com.chaerok.backend.odii.external;
+
+public record OdiiThemeItem(
+        String tid,
+        String tlid,
+        String title,
+        String mapX,
+        String mapY
+) {
+}

--- a/src/main/java/com/chaerok/backend/odii/service/OdiiService.java
+++ b/src/main/java/com/chaerok/backend/odii/service/OdiiService.java
@@ -1,0 +1,179 @@
+package com.chaerok.backend.odii.service;
+
+import com.chaerok.backend.heritage.dto.HeritagePlaceResponse;
+import com.chaerok.backend.heritage.service.HeritageService;
+import com.chaerok.backend.odii.dto.OdiiGuideResponse;
+import com.chaerok.backend.odii.external.OdiiApiClient;
+import com.chaerok.backend.odii.external.OdiiStoryItem;
+import com.chaerok.backend.odii.external.OdiiThemeItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OdiiService {
+
+    private static final Map<String, String> ODII_SEARCH_KEYWORDS = Map.of(
+            "공주 공산성", "공산성",
+            "공주 무령왕릉과 왕릉원", "무령왕릉",
+            "서동공원과 궁남지", "궁남지",
+            "부여 정림사지 오층석탑", "정림사지",
+            "관북리유적과 부소산성", "부소산성",
+            "서산 해미읍성", "해미읍성",
+            "해미국제성지", "해미순례성지",
+            "향천사", "향천사"
+    );
+
+    private final HeritageService heritageService;
+    private final OdiiApiClient odiiApiClient;
+
+    public OdiiGuideResponse getAudioGuide(Long placeId) {
+        HeritagePlaceResponse heritagePlace =
+                heritageService.getHeritagePlace(placeId);
+
+        if (!heritagePlace.heritage()) {
+            return OdiiGuideResponse.withoutOdii(
+                    heritagePlace.placeId(),
+                    heritagePlace.title(),
+                    false,
+                    heritagePlace.overview()
+            );
+        }
+
+        String keyword = resolveSearchKeyword(heritagePlace.title());
+
+        List<OdiiThemeItem> themes =
+                odiiApiClient.searchThemes(keyword);
+
+        Optional<OdiiThemeItem> selectedTheme =
+                selectTheme(themes, keyword);
+
+        if (selectedTheme.isEmpty()) {
+            return OdiiGuideResponse.withoutOdii(
+                    heritagePlace.placeId(),
+                    heritagePlace.title(),
+                    true,
+                    heritagePlace.overview()
+            );
+        }
+
+        OdiiThemeItem theme = selectedTheme.get();
+
+        List<OdiiStoryItem> stories = odiiApiClient.getStories(
+                theme.tid(),
+                theme.tlid()
+        );
+
+        Optional<OdiiStoryItem> representativeStory =
+                selectRepresentativeStory(stories, keyword);
+
+        if (representativeStory.isEmpty()) {
+            return OdiiGuideResponse.withoutOdii(
+                    heritagePlace.placeId(),
+                    heritagePlace.title(),
+                    true,
+                    heritagePlace.overview()
+            );
+        }
+
+        OdiiStoryItem story = representativeStory.get();
+
+        if (story.hasPlayableAudio()) {
+            return OdiiGuideResponse.withAudio(
+                    heritagePlace.placeId(),
+                    heritagePlace.title(),
+                    story
+            );
+        }
+
+        if (hasScript(story)) {
+            return OdiiGuideResponse.withScript(
+                    heritagePlace.placeId(),
+                    heritagePlace.title(),
+                    story
+            );
+        }
+
+        return OdiiGuideResponse.withoutOdii(
+                heritagePlace.placeId(),
+                heritagePlace.title(),
+                true,
+                heritagePlace.overview()
+        );
+    }
+
+    private String resolveSearchKeyword(String placeTitle) {
+        if (placeTitle == null || placeTitle.isBlank()) {
+            return placeTitle;
+        }
+
+        return ODII_SEARCH_KEYWORDS.entrySet().stream()
+                .filter(entry -> placeTitle.contains(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(placeTitle);
+    }
+
+    private Optional<OdiiThemeItem> selectTheme(
+            List<OdiiThemeItem> themes,
+            String keyword
+    ) {
+        if (themes == null || themes.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return themes.stream()
+                .filter(theme -> containsKeyword(theme.title(), keyword))
+                .findFirst()
+                .or(() -> themes.stream().findFirst());
+    }
+
+    private Optional<OdiiStoryItem> selectRepresentativeStory(
+            List<OdiiStoryItem> stories,
+            String keyword
+    ) {
+        if (stories == null || stories.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return stories.stream()
+                .filter(story ->
+                        isRepresentativeTitle(story.title(), keyword)
+                )
+                .findFirst()
+                .or(() -> stories.stream().findFirst());
+    }
+
+    private boolean isRepresentativeTitle(
+            String title,
+            String keyword
+    ) {
+        if (!containsKeyword(title, keyword)) {
+            return false;
+        }
+
+        // "공산성 - 금서루" 같은 세부 지점보다
+        // "공주 공산성" 같은 장소 전체 안내를 우선한다.
+        return !title.contains("-");
+    }
+
+    private boolean containsKeyword(
+            String title,
+            String keyword
+    ) {
+        return title != null
+                && keyword != null
+                && title.contains(keyword);
+    }
+
+    private boolean hasScript(OdiiStoryItem story) {
+        return story.script() != null
+                && !story.script().isBlank();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,7 +39,11 @@ external:
   tour-api:
     key: ${TOUR_API_KEY}
   odii:
-    key: ${ODII_API_KEY}
+    base-url: https://apis.data.go.kr/B551011/Odii
+    service-key: ${ODII_SERVICE_KEY}
+    mobile-os: AND
+    mobile-app: Chaerok
+    language-code: ko
 
 oauth:
   kakao:


### PR DESCRIPTION
## ✨ 변경 사항

- Odii 관광오디오서비스 연동
- Heritage 대상 장소의 대표 오디오 가이드 조회 기능 구현
- 장소명과 Odii 검색어가 다른 경우를 위한 키워드 매핑 적용
- 재생 가능한 오디오가 있으면 대표 오디오와 해설 스크립트 반환
- 오디오 없이 Odii 스크립트만 있으면 해설 스크립트 반환
- Odii 데이터가 없으면 TourAPI 소개 문구 반환
- Odii 단일 객체·배열·빈 응답 파싱 처리
- Swagger 명세 추가

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #36 

## 🧩 API / DB 변경 사항

- API 추가
  - `GET /api/odii/places/{placeId}`
  - Heritage 대상 여부 확인 후 Odii 대표 오디오 가이드 조회
  - 오디오 제공 시 `audioGuide`, `guideScript` 반환
  - 오디오 미제공 시 Odii `guideScript` 반환
  - Odii 데이터 미제공 시 `fallbackOverview`에 TourAPI 소개 문구 반환
- DB 변경 사항 없음

## ✅ 테스트

- [x] 서버 실행 확인
- [x] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- Odii API는 `themeSearchList`, `storyBasedList`를 실시간 호출하도록 구현
- 해미읍성·해미국제성지의 Odii 스크립트 반환 확인
- 향천사의 TourAPI 소개 문구 대체 반환 확인
- Heritage 비대상 장소는 Odii API를 호출하지 않도록 처리
- `tid`, `tlid`, `stid` 등 Odii 식별자는 별도 DB에 저장하지 않음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 유산지별 ODii 오디오 가이드 조회 API를 추가했습니다.
  - 오디오, 스크립트, 대체 안내문 등 가이드 제공 상태를 확인할 수 있습니다.
  - ODii 외부 서비스에서 테마와 대표 스토리를 검색하고 관련 정보를 제공합니다.
  - 오디오 재생 시간, URL, 이미지, 제목 등의 정보를 지원합니다.

- **개선**
  - 오디오 가이드가 없거나 유산 정보가 부족한 경우 대체 안내를 제공합니다.
  - 외부 서비스 응답 오류 및 유효하지 않은 결과를 안정적으로 처리합니다.
  - ODii 연동에 필요한 설정 항목을 세분화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->