### PR TITLE
fix(infra): Render 메모리 사용량 최적화

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,12 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 3
+      minimum-idle: 1
+      connection-timeout: 30000
+      idle-timeout: 30000
+      max-lifetime: 1800000
 
   jpa:
     hibernate:
@@ -21,7 +27,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
-    show-sql: true
+    show-sql: ${JPA_SHOW_SQL:false}
 
   flyway:
     enabled: true
@@ -62,3 +68,8 @@ jwt:
   access-expiration: ${JWT_ACCESS_EXPIRATION}
   refresh-expiration: ${JWT_REFRESH_EXPIRATION}
   signup-expiration: ${JWT_SIGNUP_EXPIRATION}
+
+logging:
+  level:
+    org.hibernate.SQL: WARN
+    org.hibernate.orm.jdbc.bind: WARN


### PR DESCRIPTION
## ✨ 변경 사항

- Render 512MB 메모리 제한에 맞춰 HikariCP 연결 풀 크기 축소
- 운영 환경의 Hibernate SQL 출력 비활성화
- 로컬 환경에서 필요한 경우 환경변수로 SQL 로그 활성화 가능하도록 설정

## 📌 담당 영역

- [x] 공통 설정 / 인프라
- [ ] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #38 

## 🧩 API / DB 변경 사항

- 없음

## ✅ 테스트

- [x] 서버 실행 확인
- [ ] Swagger 확인
- [ ] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- HikariCP 설정을 `maximum-pool-size: 3`, `minimum-idle: 1`로 변경
- `spring.jpa.show-sql` 기본값을 `false`로 변경
- 로컬에서 SQL 로그가 필요한 경우 `JPA_SHOW_SQL=true` 환경변수 설정 가능
- Render의 `JAVA_TOOL_OPTIONS`는 다음 값으로 별도 변경 필요

    - `-Xms64m -Xmx256m -XX:MaxMetaspaceSize=96m -XX:+UseSerialGC -Xss512k`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 데이터베이스 연결 풀 설정을 추가해 연결 관리 성능과 안정성을 개선했습니다.
  * JPA SQL 출력 여부를 환경변수로 제어할 수 있도록 변경했습니다.
  * Hibernate SQL 및 바인딩 로그를 제한해 불필요한 로그 출력을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->