### PR TITLE
fix(user): 회원 탈퇴 시 코스 데이터 연쇄 삭제 처리

### DIFF
--- a/src/main/resources/db/migration/V13__add_cascade_delete_to_courses_user_fk.sql
+++ b/src/main/resources/db/migration/V13__add_cascade_delete_to_courses_user_fk.sql
@@ -1,0 +1,8 @@
+ALTER TABLE courses
+DROP CONSTRAINT fk_courses_user;
+
+ALTER TABLE courses
+    ADD CONSTRAINT fk_courses_user
+        FOREIGN KEY (user_id)
+            REFERENCES users(id)
+            ON DELETE CASCADE;


### PR DESCRIPTION
## ✨ 변경 사항

- 회원 탈퇴 시 사용자와 연관된 코스 데이터가 함께 삭제되도록 외래 키 삭제 정책 수정
- `courses.user_id` 외래 키에 `ON DELETE CASCADE` 적용
- 사용자 삭제 시 `courses`와 하위 `course_places`가 순차적으로 연쇄 삭제되도록 처리

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [x] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #40 

## 🧩 API / DB 변경 사항

- API 요청 및 응답 형식 변경 없음
- `courses.user_id` 외래 키 제약조건 변경
  - 기존: 사용자 삭제 시 코스 데이터가 존재하면 삭제 실패
  - 변경: 사용자 삭제 시 해당 사용자의 코스 데이터 자동 삭제
- `course_places.course_id`에는 기존 `ON DELETE CASCADE`가 적용되어 있어 코스 삭제 시 하위 장소 데이터도 함께 삭제

## ✅ 테스트

- [x] 서버 실행 확인
- [ ] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- Flyway 마이그레이션 파일 `V13__add_cascade_delete_to_courses_user_fk.sql` 추가
- 기존 회원 탈퇴 API의 Java 로직은 변경하지 않고 DB 외래 키 삭제 정책만 수정
- 사용자 삭제 시 연쇄 삭제 흐름
  - `users` 삭제
  - `courses` 자동 삭제
  - `course_places` 자동 삭제
- `refresh_tokens.user_id`에는 기존에 `ON DELETE CASCADE`가 적용되어 있음