### PR TITLE
feat(infra): JVM 모니터링 및 Actuator 보안 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ dependencies {
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'
 
+	// Monitoring
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/chaerok/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/chaerok/backend/global/config/SecurityConfig.java
@@ -3,10 +3,18 @@ package com.chaerok.backend.global.config;
 import com.chaerok.backend.auth.security.JwtAuthenticationEntryPoint;
 import com.chaerok.backend.auth.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.http.HttpMethod;
@@ -18,7 +26,64 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
+    @Value("${monitoring.username}")
+    private String monitoringUsername;
+
+    @Value("${monitoring.password}")
+    private String monitoringPassword;
+
     @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public InMemoryUserDetailsManager monitoringUserDetailsService(
+            PasswordEncoder passwordEncoder
+    ) {
+        UserDetails monitoringUser = User.withUsername(monitoringUsername)
+                .password(passwordEncoder.encode(monitoringPassword))
+                .roles("MONITOR")
+                .build();
+
+        return new InMemoryUserDetailsManager(monitoringUser);
+    }
+
+    @Bean
+    @Order(1)
+    public SecurityFilterChain actuatorSecurityFilterChain(
+            HttpSecurity http
+    ) throws Exception {
+
+        http
+                .securityMatcher("/actuator/**")
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+
+                .httpBasic(Customizer.withDefaults())
+
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(
+                                SessionCreationPolicy.STATELESS
+                        )
+                )
+
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/health")
+                        .permitAll()
+
+                        .requestMatchers("/actuator/prometheus")
+                        .hasRole("MONITOR")
+
+                        .anyRequest()
+                        .denyAll()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    @Order(2)
     public SecurityFilterChain securityFilterChain(
             HttpSecurity http
     ) throws Exception {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,3 +74,13 @@ logging:
   level:
     org.hibernate.SQL: WARN
     org.hibernate.orm.jdbc.bind: WARN
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+
+monitoring:
+  username: ${ACTUATOR_USERNAME}
+  password: ${ACTUATOR_PASSWORD}


### PR DESCRIPTION
## ✨ 변경 사항

- Spring Boot Actuator 및 Micrometer Prometheus Registry 추가
- JVM Heap / Non-Heap / Metaspace / 클래스 로딩 / GC / HTTP / HikariCP 지표 노출
- `/actuator/health` 공개 접근 및 `/actuator/prometheus` Basic Auth 보호
- 모니터링 전용 계정을 환경변수 기반으로 구성

## 📌 담당 영역

- [x] 공통 설정 / 인프라
- [ ] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #46 

## 🧩 API / DB 변경 사항

- 비즈니스 API 변경 없음
- DB 변경 없음
- Actuator endpoint 추가
  - `GET /actuator/health`
  - `GET /actuator/prometheus`
- `/actuator/prometheus`는 모니터링 전용 Basic Auth 인증 필요

## ✅ 테스트

- [x] 서버 실행 확인
- [x] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- Render 환경에서 발생한 `OutOfMemoryError: Metaspace` 원인 분석을 위해 JVM 내부 지표를 추가함
- `/actuator/health`는 인증 없이 접근 가능하며 `/actuator/prometheus`는 모니터링 전용 계정으로만 접근 가능함
- 모니터링 계정 정보는 `ACTUATOR_USERNAME`, `ACTUATOR_PASSWORD` 환경변수로 관리함
- 로컬에서 인증 없이 `/actuator/prometheus` 접근 시 401 응답, Basic Auth 인증 후 Prometheus 지표 정상 조회 확인
- JVM 메모리 제한값은 변경하지 않고 기존 조건에서 Render 배포 후 Metaspace 사용량과 Loaded Classes를 측정할 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 애플리케이션 상태 확인을 위한 Health 모니터링 엔드포인트를 제공합니다.
  * Prometheus 기반 모니터링 지표를 조회할 수 있습니다.
  * 모니터링 지표 조회에는 인증이 필요하며, 인증 정보는 환경 변수로 설정할 수 있습니다.
  * 모니터링 관련 요청에 대한 접근 권한을 엔드포인트별로 관리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->