### PR TITLE
feat: 렌더 실패 정책 및 이미지 입력 제한 강화

### DIFF
--- a/lambda/render/src/main/java/com/chaerok/render/RenderHandler.java
+++ b/lambda/render/src/main/java/com/chaerok/render/RenderHandler.java
@@ -4,15 +4,13 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
-import com.chaerok.render.media.MediaGenerationException;
 import com.chaerok.render.message.RenderQueueMessage;
 import com.chaerok.render.output.RenderOutput;
+import com.chaerok.render.pipeline.RenderFailureException;
 import com.chaerok.render.pipeline.RenderPipeline;
-import com.chaerok.render.pipeline.RenderPipelineException;
 import com.chaerok.render.result.RenderResultMessage;
 import com.chaerok.render.result.RenderResultPublisher;
 import com.chaerok.render.retry.RenderRetryConfig;
-import com.chaerok.render.storage.ObjectStorageOperationException;
 import com.chaerok.render.validation.InvalidRenderMessageException;
 import com.chaerok.render.validation.RenderMessageValidator;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -329,6 +327,12 @@ public class RenderHandler
     }
 
     private boolean isRetryable(Exception exception) {
+        RenderFailureException renderFailure =
+                findRenderFailure(exception);
+        if (renderFailure != null) {
+            return renderFailure.retryable();
+        }
+
         return !hasCause(
                 exception,
                 InvalidRenderMessageException.class
@@ -336,25 +340,32 @@ public class RenderHandler
     }
 
     private String errorCode(Exception exception) {
+        RenderFailureException renderFailure =
+                findRenderFailure(exception);
+        if (renderFailure != null) {
+            return renderFailure.errorCode();
+        }
+
         if (hasCause(exception, InvalidRenderMessageException.class)) {
             return "INVALID_RENDER_MESSAGE";
         }
         if (hasCause(exception, IllegalArgumentException.class)) {
             return "INVALID_RENDER_REQUEST";
         }
-        if (hasCause(
-                exception,
-                ObjectStorageOperationException.class
-        )) {
-            return "OBJECT_STORAGE_FAILED";
-        }
-        if (hasCause(exception, MediaGenerationException.class)) {
-            return "MEDIA_GENERATION_FAILED";
-        }
-        if (hasCause(exception, RenderPipelineException.class)) {
-            return "RENDER_PIPELINE_FAILED";
-        }
         return "RENDER_EXECUTION_FAILED";
+    }
+
+    private RenderFailureException findRenderFailure(
+            Throwable throwable
+    ) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof RenderFailureException failure) {
+                return failure;
+            }
+            current = current.getCause();
+        }
+        return null;
     }
 
     private boolean hasCause(

--- a/lambda/render/src/main/java/com/chaerok/render/pipeline/RenderFailureException.java
+++ b/lambda/render/src/main/java/com/chaerok/render/pipeline/RenderFailureException.java
@@ -1,0 +1,46 @@
+package com.chaerok.render.pipeline;
+
+public final class RenderFailureException
+        extends RenderPipelineException {
+
+    private final String errorCode;
+    private final boolean retryable;
+
+    public RenderFailureException(
+            String errorCode,
+            boolean retryable,
+            String message
+    ) {
+        super(message);
+        this.errorCode = requireErrorCode(errorCode);
+        this.retryable = retryable;
+    }
+
+    public RenderFailureException(
+            String errorCode,
+            boolean retryable,
+            String message,
+            Throwable cause
+    ) {
+        super(message, cause);
+        this.errorCode = requireErrorCode(errorCode);
+        this.retryable = retryable;
+    }
+
+    public String errorCode() {
+        return errorCode;
+    }
+
+    public boolean retryable() {
+        return retryable;
+    }
+
+    private static String requireErrorCode(String errorCode) {
+        if (errorCode == null || errorCode.isBlank()) {
+            throw new IllegalArgumentException(
+                    "errorCode is required."
+            );
+        }
+        return errorCode;
+    }
+}

--- a/lambda/render/src/main/java/com/chaerok/render/pipeline/RenderPipeline.java
+++ b/lambda/render/src/main/java/com/chaerok/render/pipeline/RenderPipeline.java
@@ -13,6 +13,8 @@ import com.chaerok.render.workspace.RenderWorkspace;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -21,13 +23,15 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
 
 public final class RenderPipeline {
 
-    private static final int MAX_IMAGE_WIDTH = 6000;
-    private static final int MAX_IMAGE_HEIGHT = 6000;
+    private static final int MAX_IMAGE_DIMENSION = 6000;
+    private static final long MAX_IMAGE_PIXELS = 16_000_000L;
+    private static final String JPEG_FORMAT = "JPEG";
 
     private final ObjectStorage objectStorage;
     private final FilmFilterEngine filmFilterEngine;
@@ -111,14 +115,32 @@ public final class RenderPipeline {
             }
 
             safeLogger.accept("Creating filtered photo ZIP.");
-            zipWriter.write(filteredFiles, workspace.zipFile());
+            try {
+                zipWriter.write(filteredFiles, workspace.zipFile());
+            } catch (RuntimeException exception) {
+                throw failure(
+                        "ZIP_GENERATION_FAILED",
+                        true,
+                        "Failed to create filtered photo ZIP.",
+                        exception
+                );
+            }
 
             safeLogger.accept("Rendering 9:16 MP4 with FFmpeg.");
-            reelRenderer.render(
-                    workspace.filteredDirectory(),
-                    filteredFiles.size(),
-                    workspace.reelFile()
-            );
+            try {
+                reelRenderer.render(
+                        workspace.filteredDirectory(),
+                        filteredFiles.size(),
+                        workspace.reelFile()
+                );
+            } catch (RuntimeException exception) {
+                throw failure(
+                        "REEL_GENERATION_FAILED",
+                        true,
+                        "Failed to render reel MP4.",
+                        exception
+                );
+            }
 
             RenderOutput output = createOutput(
                     message,
@@ -133,7 +155,6 @@ public final class RenderPipeline {
         }
     }
 
-
     private RenderOutput loadCompletedOutput(
             RenderQueueMessage message,
             RenderWorkspace workspace,
@@ -141,7 +162,22 @@ public final class RenderPipeline {
     ) {
         String manifestObjectKey = RenderObjectKeys.manifest(message);
 
-        if (!objectStorage.exists(message.bucket(), manifestObjectKey)) {
+        boolean manifestExists;
+        try {
+            manifestExists = objectStorage.exists(
+                    message.bucket(),
+                    manifestObjectKey
+            );
+        } catch (RuntimeException exception) {
+            throw failure(
+                    "MANIFEST_LOOKUP_FAILED",
+                    true,
+                    "Failed to check existing render manifest.",
+                    exception
+            );
+        }
+
+        if (!manifestExists) {
             return null;
         }
 
@@ -150,11 +186,20 @@ public final class RenderPipeline {
                         + manifestObjectKey
         );
 
-        objectStorage.download(
-                message.bucket(),
-                manifestObjectKey,
-                workspace.manifestFile()
-        );
+        try {
+            objectStorage.download(
+                    message.bucket(),
+                    manifestObjectKey,
+                    workspace.manifestFile()
+            );
+        } catch (RuntimeException exception) {
+            throw failure(
+                    "MANIFEST_DOWNLOAD_FAILED",
+                    true,
+                    "Failed to download existing render manifest.",
+                    exception
+            );
+        }
 
         try {
             RenderOutput output = objectMapper.readValue(
@@ -165,15 +210,21 @@ public final class RenderPipeline {
             if (!message.renderJobId().equals(output.renderJobId())
                     || !message.filmRollId().equals(output.filmRollId())
                     || !"COMPLETED".equals(output.status())) {
-                throw new RenderPipelineException(
+                throw failure(
+                        "MANIFEST_INVALID",
+                        false,
                         "Existing manifest does not match render request."
                 );
             }
 
             return output;
-        } catch (IOException exception) {
-            throw new RenderPipelineException(
-                    "Failed to read existing render manifest.",
+        } catch (RenderFailureException exception) {
+            throw exception;
+        } catch (IOException | RuntimeException exception) {
+            throw failure(
+                    "MANIFEST_INVALID",
+                    false,
+                    "Existing render manifest is invalid or unreadable.",
                     exception
             );
         }
@@ -195,40 +246,99 @@ public final class RenderPipeline {
                         + photo.originalObjectKey()
         );
 
-        objectStorage.download(
-                message.bucket(),
-                photo.originalObjectKey(),
-                source
-        );
+        try {
+            objectStorage.download(
+                    message.bucket(),
+                    photo.originalObjectKey(),
+                    source
+            );
+        } catch (RuntimeException exception) {
+            throw photoFailure(
+                    "PHOTO_DOWNLOAD_FAILED",
+                    true,
+                    "DOWNLOAD",
+                    photo,
+                    exception
+            );
+        }
 
-        BufferedImage original = readImage(source);
-        validateImageSize(original, photo.sequence());
+        inspectImageBeforeDecode(source, photo);
+        BufferedImage original = readImage(source, photo);
 
-        BufferedImage filteredImage = filmFilterEngine.apply(
-                original,
-                message.filterId(),
-                message.filterStrength()
-        );
+        BufferedImage filteredImage;
+        try {
+            filteredImage = filmFilterEngine.apply(
+                    original,
+                    message.filterId(),
+                    message.filterStrength()
+            );
+        } catch (RuntimeException exception) {
+            throw photoFailure(
+                    "PHOTO_FILTER_FAILED",
+                    false,
+                    "FILTER",
+                    photo,
+                    exception
+            );
+        }
 
-        jpegImageWriter.write(filteredImage, filtered);
+        try {
+            jpegImageWriter.write(filteredImage, filtered);
+        } catch (RuntimeException exception) {
+            throw photoFailure(
+                    "PHOTO_ENCODE_FAILED",
+                    true,
+                    "ENCODE",
+                    photo,
+                    exception
+            );
+        }
+
+        long filteredFileSize;
+        try {
+            filteredFileSize = Files.size(filtered);
+            if (filteredFileSize <= 0L) {
+                throw new IOException(
+                        "Filtered JPEG is empty: " + filtered
+                );
+            }
+        } catch (IOException exception) {
+            throw photoFailure(
+                    "PHOTO_ENCODE_FAILED",
+                    true,
+                    "ENCODE_VERIFY",
+                    photo,
+                    exception
+            );
+        }
 
         String objectKey = RenderObjectKeys.filteredPhoto(
                 message,
                 photo.sequence()
         );
 
-        objectStorage.upload(
-                message.bucket(),
-                objectKey,
-                filtered,
-                "image/jpeg"
-        );
+        try {
+            objectStorage.upload(
+                    message.bucket(),
+                    objectKey,
+                    filtered,
+                    "image/jpeg"
+            );
+        } catch (RuntimeException exception) {
+            throw photoFailure(
+                    "PHOTO_UPLOAD_FAILED",
+                    true,
+                    "UPLOAD",
+                    photo,
+                    exception
+            );
+        }
 
         return new FilteredPhotoOutput(
                 photo.photoId(),
                 photo.sequence(),
                 objectKey,
-                fileSize(filtered)
+                filteredFileSize
         );
     }
 
@@ -237,6 +347,17 @@ public final class RenderPipeline {
             List<FilteredPhotoOutput> filteredOutputs,
             RenderWorkspace workspace
     ) {
+        long zipFileSize = fileSize(
+                workspace.zipFile(),
+                "ZIP_GENERATION_FAILED",
+                "Failed to verify filtered photo ZIP."
+        );
+        long reelFileSize = fileSize(
+                workspace.reelFile(),
+                "REEL_GENERATION_FAILED",
+                "Failed to verify reel MP4."
+        );
+
         return new RenderOutput(
                 RenderOutput.CURRENT_SCHEMA_VERSION,
                 message.renderJobId(),
@@ -244,9 +365,9 @@ public final class RenderPipeline {
                 "COMPLETED",
                 filteredOutputs,
                 RenderObjectKeys.zip(message),
-                fileSize(workspace.zipFile()),
+                zipFileSize,
                 RenderObjectKeys.reel(message),
-                fileSize(workspace.reelFile()),
+                reelFileSize,
                 RenderObjectKeys.manifest(message),
                 Instant.now(clock)
         );
@@ -259,64 +380,176 @@ public final class RenderPipeline {
             Consumer<String> logger
     ) {
         logger.accept("Uploading ZIP: " + output.zipObjectKey());
-        objectStorage.upload(
-                message.bucket(),
-                output.zipObjectKey(),
-                workspace.zipFile(),
-                "application/zip"
-        );
+        try {
+            objectStorage.upload(
+                    message.bucket(),
+                    output.zipObjectKey(),
+                    workspace.zipFile(),
+                    "application/zip"
+            );
+        } catch (RuntimeException exception) {
+            throw failure(
+                    "ZIP_UPLOAD_FAILED",
+                    true,
+                    "Failed to upload filtered photo ZIP.",
+                    exception
+            );
+        }
 
         logger.accept("Uploading MP4: " + output.reelObjectKey());
-        objectStorage.upload(
-                message.bucket(),
-                output.reelObjectKey(),
-                workspace.reelFile(),
-                "video/mp4"
-        );
+        try {
+            objectStorage.upload(
+                    message.bucket(),
+                    output.reelObjectKey(),
+                    workspace.reelFile(),
+                    "video/mp4"
+            );
+        } catch (RuntimeException exception) {
+            throw failure(
+                    "REEL_UPLOAD_FAILED",
+                    true,
+                    "Failed to upload reel MP4.",
+                    exception
+            );
+        }
 
         logger.accept(
                 "Uploading manifest: " + output.manifestObjectKey()
         );
-        objectStorage.upload(
-                message.bucket(),
-                output.manifestObjectKey(),
-                workspace.manifestFile(),
-                "application/json"
-        );
+        try {
+            objectStorage.upload(
+                    message.bucket(),
+                    output.manifestObjectKey(),
+                    workspace.manifestFile(),
+                    "application/json"
+            );
+        } catch (RuntimeException exception) {
+            throw failure(
+                    "MANIFEST_UPLOAD_FAILED",
+                    true,
+                    "Failed to upload render manifest.",
+                    exception
+            );
+        }
     }
 
-    private BufferedImage readImage(Path source) {
+    private void inspectImageBeforeDecode(
+            Path source,
+            RenderQueueMessage.PhotoItem photo
+    ) {
+        try (ImageInputStream input =
+                     ImageIO.createImageInputStream(source.toFile())) {
+            if (input == null) {
+                throw photoFailure(
+                        "PHOTO_INVALID_IMAGE",
+                        false,
+                        "READ_HEADER",
+                        photo,
+                        "image input stream is unavailable"
+                );
+            }
+
+            Iterator<ImageReader> readers = ImageIO.getImageReaders(input);
+            if (!readers.hasNext()) {
+                throw photoFailure(
+                        "PHOTO_INVALID_IMAGE",
+                        false,
+                        "READ_HEADER",
+                        photo,
+                        "unsupported or invalid image header"
+                );
+            }
+
+            ImageReader reader = readers.next();
+            try {
+                reader.setInput(input, true, true);
+
+                String formatName = reader.getFormatName();
+                if (!JPEG_FORMAT.equalsIgnoreCase(formatName)) {
+                    throw photoFailure(
+                            "PHOTO_INVALID_IMAGE",
+                            false,
+                            "READ_HEADER",
+                            photo,
+                            "expected JPEG but detected " + formatName
+                    );
+                }
+
+                int width = reader.getWidth(0);
+                int height = reader.getHeight(0);
+                validateImageSize(width, height, photo);
+            } finally {
+                reader.dispose();
+            }
+        } catch (RenderFailureException exception) {
+            throw exception;
+        } catch (IOException | RuntimeException exception) {
+            throw photoFailure(
+                    "PHOTO_INVALID_IMAGE",
+                    false,
+                    "READ_HEADER",
+                    photo,
+                    exception
+            );
+        }
+    }
+
+    private BufferedImage readImage(
+            Path source,
+            RenderQueueMessage.PhotoItem photo
+    ) {
         try {
             BufferedImage image = ImageIO.read(source.toFile());
             if (image == null) {
-                throw new RenderPipelineException(
-                        "Unsupported or invalid image: " + source
+                throw photoFailure(
+                        "PHOTO_INVALID_IMAGE",
+                        false,
+                        "DECODE",
+                        photo,
+                        "JPEG decode returned no image"
                 );
             }
             return image;
-        } catch (IOException exception) {
-            throw new RenderPipelineException(
-                    "Failed to read image: " + source,
+        } catch (RenderFailureException exception) {
+            throw exception;
+        } catch (IOException | RuntimeException exception) {
+            throw photoFailure(
+                    "PHOTO_INVALID_IMAGE",
+                    false,
+                    "DECODE",
+                    photo,
                     exception
             );
         }
     }
 
     private void validateImageSize(
-            BufferedImage image,
-            int sequence
+            int width,
+            int height,
+            RenderQueueMessage.PhotoItem photo
     ) {
-        if (image.getWidth() <= 0 || image.getHeight() <= 0) {
-            throw new RenderPipelineException(
-                    "Invalid image dimensions for sequence=" + sequence
+        if (width <= 0 || height <= 0) {
+            throw photoFailure(
+                    "PHOTO_INVALID_IMAGE",
+                    false,
+                    "VALIDATE_DIMENSIONS",
+                    photo,
+                    "width=" + width + ", height=" + height
             );
         }
 
-        if (image.getWidth() > MAX_IMAGE_WIDTH
-                || image.getHeight() > MAX_IMAGE_HEIGHT) {
-            throw new RenderPipelineException(
-                    "Image exceeds maximum dimensions for sequence="
-                            + sequence
+        long pixels = (long) width * height;
+        if (width > MAX_IMAGE_DIMENSION
+                || height > MAX_IMAGE_DIMENSION
+                || pixels > MAX_IMAGE_PIXELS) {
+            throw photoFailure(
+                    "PHOTO_TOO_LARGE",
+                    false,
+                    "VALIDATE_DIMENSIONS",
+                    photo,
+                    "width=" + width
+                            + ", height=" + height
+                            + ", pixels=" + pixels
             );
         }
     }
@@ -328,23 +561,132 @@ public final class RenderPipeline {
         try {
             objectMapper.writerWithDefaultPrettyPrinter()
                     .writeValue(destination.toFile(), output);
-        } catch (IOException exception) {
-            throw new RenderPipelineException(
+        } catch (IOException | RuntimeException exception) {
+            throw failure(
+                    "MANIFEST_GENERATION_FAILED",
+                    true,
                     "Failed to write render manifest.",
                     exception
             );
         }
     }
 
-    private long fileSize(Path path) {
+    private long fileSize(
+            Path path,
+            String errorCode,
+            String message
+    ) {
         try {
-            return Files.size(path);
+            long size = Files.size(path);
+            if (size <= 0L) {
+                throw new IOException("Generated file is empty: " + path);
+            }
+            return size;
         } catch (IOException exception) {
-            throw new RenderPipelineException(
-                    "Failed to read file size: " + path,
+            throw failure(
+                    errorCode,
+                    true,
+                    message,
                     exception
             );
         }
+    }
+
+    private RenderFailureException photoFailure(
+            String errorCode,
+            boolean retryable,
+            String stage,
+            RenderQueueMessage.PhotoItem photo,
+            Throwable cause
+    ) {
+        String detail = cause == null
+                ? null
+                : cause.getMessage();
+        return photoFailure(
+                errorCode,
+                retryable,
+                stage,
+                photo,
+                detail,
+                cause
+        );
+    }
+
+    private RenderFailureException photoFailure(
+            String errorCode,
+            boolean retryable,
+            String stage,
+            RenderQueueMessage.PhotoItem photo,
+            String detail
+    ) {
+        return photoFailure(
+                errorCode,
+                retryable,
+                stage,
+                photo,
+                detail,
+                null
+        );
+    }
+
+    private RenderFailureException photoFailure(
+            String errorCode,
+            boolean retryable,
+            String stage,
+            RenderQueueMessage.PhotoItem photo,
+            String detail,
+            Throwable cause
+    ) {
+        StringBuilder message = new StringBuilder()
+                .append("stage=")
+                .append(stage)
+                .append(", photoId=")
+                .append(photo.photoId())
+                .append(", sequence=")
+                .append(photo.sequence());
+
+        if (detail != null && !detail.isBlank()) {
+            message.append(", detail=").append(detail);
+        }
+
+        return cause == null
+                ? new RenderFailureException(
+                        errorCode,
+                        retryable,
+                        message.toString()
+                )
+                : new RenderFailureException(
+                        errorCode,
+                        retryable,
+                        message.toString(),
+                        cause
+                );
+    }
+
+    private RenderFailureException failure(
+            String errorCode,
+            boolean retryable,
+            String message,
+            Throwable cause
+    ) {
+        return new RenderFailureException(
+                errorCode,
+                retryable,
+                message,
+                cause
+        );
+    }
+
+    private RenderFailureException failure(
+            String errorCode,
+            boolean retryable,
+            String message
+    ) {
+        return new RenderFailureException(
+                errorCode,
+                retryable,
+                message
+        );
     }
 
     private static <T> T require(T value, String name) {

--- a/lambda/render/src/test/java/com/chaerok/render/RenderHandlerTest.java
+++ b/lambda/render/src/test/java/com/chaerok/render/RenderHandlerTest.java
@@ -135,6 +135,122 @@ class RenderHandlerTest {
     }
 
     @Test
+    @DisplayName("깨진 JPEG는 재시도하지 않고 사진 식별 정보와 함께 실패 처리한다")
+    void publishesNonRetryableFailureForInvalidImage() {
+        InMemoryObjectStorage storage = new InMemoryObjectStorage();
+        storage.put(
+                "users/6/rolls/2/original/photo.jpg",
+                "not-a-jpeg".getBytes(StandardCharsets.UTF_8)
+        );
+        CapturingResultPublisher publisher =
+                new CapturingResultPublisher();
+        RenderHandler handler = createHandler(storage, publisher);
+
+        SQSBatchResponse response = handler.handleRequest(
+                event("message-invalid-image", validBody(), "1"),
+                new TestContext()
+        );
+
+        assertThat(response.getBatchItemFailures()).isEmpty();
+        assertThat(publisher.messages()).hasSize(1);
+
+        RenderResultMessage result = publisher.messages().get(0);
+        assertThat(result.errorCode()).isEqualTo("PHOTO_INVALID_IMAGE");
+        assertThat(result.retryable()).isFalse();
+        assertThat(result.errorMessage())
+                .contains("stage=READ_HEADER")
+                .contains("photoId=1")
+                .contains("sequence=1");
+    }
+
+    @Test
+    @DisplayName("6000px 이하여도 16MP를 넘는 JPEG는 디코딩 전에 거부한다")
+    void rejectsImageThatExceedsPixelLimitBeforeDecode() throws Exception {
+        InMemoryObjectStorage storage = new InMemoryObjectStorage();
+        storage.put(
+                "users/6/rolls/2/original/photo.jpg",
+                createJpegWithDimensions(5000, 4000)
+        );
+        CapturingResultPublisher publisher =
+                new CapturingResultPublisher();
+        RenderHandler handler = createHandler(storage, publisher);
+
+        SQSBatchResponse response = handler.handleRequest(
+                event("message-too-large", validBody(), "1"),
+                new TestContext()
+        );
+
+        assertThat(response.getBatchItemFailures()).isEmpty();
+        assertThat(publisher.messages()).hasSize(1);
+
+        RenderResultMessage result = publisher.messages().get(0);
+        assertThat(result.errorCode()).isEqualTo("PHOTO_TOO_LARGE");
+        assertThat(result.errorMessage())
+                .contains("width=5000")
+                .contains("height=4000")
+                .contains("pixels=20000000");
+    }
+
+    @Test
+    @DisplayName("필터 처리의 결정적 실패는 재시도하지 않는다")
+    void publishesNonRetryableFailureForFilterError() throws Exception {
+        InMemoryObjectStorage storage = new InMemoryObjectStorage();
+        storage.put(
+                "users/6/rolls/2/original/photo.jpg",
+                createJpeg()
+        );
+        CapturingResultPublisher publisher =
+                new CapturingResultPublisher();
+        RenderHandler handler = createHandler(storage, publisher);
+
+        String unsupportedFilterBody = validBody().replace(
+                "\"gongju\"",
+                "\"unsupported-filter\""
+        );
+
+        SQSBatchResponse response = handler.handleRequest(
+                event("message-filter-fail", unsupportedFilterBody, "1"),
+                new TestContext()
+        );
+
+        assertThat(response.getBatchItemFailures()).isEmpty();
+        assertThat(publisher.messages()).hasSize(1);
+
+        RenderResultMessage result = publisher.messages().get(0);
+        assertThat(result.errorCode()).isEqualTo("PHOTO_FILTER_FAILED");
+        assertThat(result.retryable()).isFalse();
+        assertThat(result.errorMessage())
+                .contains("stage=FILTER")
+                .contains("photoId=1")
+                .contains("sequence=1");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 기존 manifest는 재시도하지 않는다")
+    void publishesNonRetryableFailureForInvalidManifest() {
+        InMemoryObjectStorage storage = new InMemoryObjectStorage();
+        storage.put(
+                "users/6/rolls/2/render-jobs/"
+                        + "133d6ee3-a120-4df3-8ba3-f60adbdd64d6/"
+                        + "manifest.json",
+                "{invalid-json".getBytes(StandardCharsets.UTF_8)
+        );
+        CapturingResultPublisher publisher =
+                new CapturingResultPublisher();
+        RenderHandler handler = createHandler(storage, publisher);
+
+        SQSBatchResponse response = handler.handleRequest(
+                event("message-invalid-manifest", validBody(), "1"),
+                new TestContext()
+        );
+
+        assertThat(response.getBatchItemFailures()).isEmpty();
+        assertThat(publisher.messages()).hasSize(1);
+        assertThat(publisher.messages().get(0).errorCode())
+                .isEqualTo("MANIFEST_INVALID");
+    }
+
+    @Test
     @DisplayName("재시도 중인 실행 실패는 terminal FAILED 결과를 발행하지 않는다")
     void doesNotPublishTerminalFailureBeforeFinalAttempt() {
         CapturingResultPublisher publisher =
@@ -186,7 +302,79 @@ class RenderHandlerTest {
         assertThat(result.retryable()).isFalse();
         assertThat(result.attempt()).isEqualTo(3);
         assertThat(result.errorCode())
-                .isEqualTo("RENDER_EXECUTION_FAILED");
+                .isEqualTo("PHOTO_DOWNLOAD_FAILED");
+        assertThat(result.errorMessage())
+                .contains("stage=DOWNLOAD")
+                .contains("photoId=1")
+                .contains("sequence=1");
+    }
+
+    @Test
+    @DisplayName("릴스 생성 실패는 마지막 시도까지 재시도한 뒤 실패 처리한다")
+    void publishesReelGenerationFailureOnFinalAttempt() throws Exception {
+        InMemoryObjectStorage storage = new InMemoryObjectStorage();
+        storage.put(
+                "users/6/rolls/2/original/photo.jpg",
+                createJpeg()
+        );
+        CapturingResultPublisher publisher =
+                new CapturingResultPublisher();
+        ReelRenderer failingReelRenderer = (
+                filteredDirectory,
+                photoCount,
+                destination
+        ) -> {
+            throw new IllegalStateException("fake ffmpeg failure");
+        };
+        RenderHandler handler = createHandler(
+                storage,
+                publisher,
+                failingReelRenderer
+        );
+
+        SQSBatchResponse response = handler.handleRequest(
+                event("message-reel-fail", validBody(), "3"),
+                new TestContext()
+        );
+
+        assertThat(response.getBatchItemFailures())
+                .extracting(
+                        SQSBatchResponse.BatchItemFailure
+                                ::getItemIdentifier
+                )
+                .containsExactly("message-reel-fail");
+        assertThat(publisher.messages()).hasSize(1);
+        assertThat(publisher.messages().get(0).errorCode())
+                .isEqualTo("REEL_GENERATION_FAILED");
+    }
+
+    @Test
+    @DisplayName("ZIP 업로드 실패는 마지막 시도에 ZIP_UPLOAD_FAILED로 기록한다")
+    void publishesZipUploadFailureOnFinalAttempt() throws Exception {
+        InMemoryObjectStorage storage = new InMemoryObjectStorage();
+        storage.put(
+                "users/6/rolls/2/original/photo.jpg",
+                createJpeg()
+        );
+        storage.failUploadsEndingWith(".zip");
+        CapturingResultPublisher publisher =
+                new CapturingResultPublisher();
+        RenderHandler handler = createHandler(storage, publisher);
+
+        SQSBatchResponse response = handler.handleRequest(
+                event("message-zip-upload-fail", validBody(), "3"),
+                new TestContext()
+        );
+
+        assertThat(response.getBatchItemFailures())
+                .extracting(
+                        SQSBatchResponse.BatchItemFailure
+                                ::getItemIdentifier
+                )
+                .containsExactly("message-zip-upload-fail");
+        assertThat(publisher.messages()).hasSize(1);
+        assertThat(publisher.messages().get(0).errorCode())
+                .isEqualTo("ZIP_UPLOAD_FAILED");
     }
 
     @Test
@@ -219,6 +407,40 @@ class RenderHandlerTest {
     }
 
     @Test
+    @DisplayName("COMPLETED 결과 발행 재시도는 기존 manifest를 재사용한다")
+    void reusesManifestWhenCompletedResultPublishIsRetried()
+            throws Exception {
+        InMemoryObjectStorage storage = new InMemoryObjectStorage();
+        storage.put(
+                "users/6/rolls/2/original/photo.jpg",
+                createJpeg()
+        );
+        FailOnceResultPublisher publisher =
+                new FailOnceResultPublisher();
+        RenderHandler handler = createHandler(storage, publisher);
+
+        SQSBatchResponse first = handler.handleRequest(
+                event("message-result-retry", validBody(), "1"),
+                new TestContext()
+        );
+        int uploadsAfterFirstAttempt = storage.uploadCount();
+
+        SQSBatchResponse second = handler.handleRequest(
+                event("message-result-retry", validBody(), "2"),
+                new TestContext()
+        );
+
+        assertThat(first.getBatchItemFailures()).hasSize(1);
+        assertThat(second.getBatchItemFailures()).isEmpty();
+        assertThat(uploadsAfterFirstAttempt).isEqualTo(4);
+        assertThat(storage.uploadCount())
+                .isEqualTo(uploadsAfterFirstAttempt);
+        assertThat(publisher.messages()).hasSize(2);
+        assertThat(publisher.messages())
+                .allMatch(message -> "COMPLETED".equals(message.status()));
+    }
+
+    @Test
     @DisplayName("식별자가 없는 잘못된 메시지는 결과 큐에 발행하지 않는다")
     void skipsFailedPublishWithoutIdentifiers() {
         CapturingResultPublisher publisher =
@@ -245,6 +467,18 @@ class RenderHandlerTest {
             InMemoryObjectStorage storage,
             RenderResultPublisher publisher
     ) {
+        return createHandler(
+                storage,
+                publisher,
+                successfulReelRenderer()
+        );
+    }
+
+    private RenderHandler createHandler(
+            InMemoryObjectStorage storage,
+            RenderResultPublisher publisher,
+            ReelRenderer reelRenderer
+    ) {
         ObjectMapper objectMapper = RenderRuntimeFactory.objectMapper();
 
         FilmFilterEngine filterEngine = new FilmFilterEngine(
@@ -255,30 +489,13 @@ class RenderHandlerTest {
                 new FilterOverlayTuningPolicy()
         );
 
-        ReelRenderer fakeReelRenderer = (
-                filteredDirectory,
-                photoCount,
-                destination
-        ) -> {
-            try {
-                Files.createDirectories(destination.getParent());
-                Files.writeString(
-                        destination,
-                        "fake-mp4-" + photoCount,
-                        StandardCharsets.UTF_8
-                );
-            } catch (IOException exception) {
-                throw new RuntimeException(exception);
-            }
-        };
-
         Clock clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
         RenderPipeline pipeline = new RenderPipeline(
                 storage,
                 filterEngine,
                 new JpegImageWriter(),
                 new FilteredPhotoZipWriter(),
-                fakeReelRenderer,
+                reelRenderer,
                 objectMapper,
                 clock
         );
@@ -291,6 +508,21 @@ class RenderHandlerTest {
                 clock,
                 new RenderRetryConfig(3)
         );
+    }
+
+    private ReelRenderer successfulReelRenderer() {
+        return (filteredDirectory, photoCount, destination) -> {
+            try {
+                Files.createDirectories(destination.getParent());
+                Files.writeString(
+                        destination,
+                        "fake-mp4-" + photoCount,
+                        StandardCharsets.UTF_8
+                );
+            } catch (IOException exception) {
+                throw new RuntimeException(exception);
+            }
+        };
     }
 
     private SQSEvent event(
@@ -373,6 +605,40 @@ class RenderHandlerTest {
         return output.toByteArray();
     }
 
+    private byte[] createJpegWithDimensions(
+            int width,
+            int height
+    ) throws IOException {
+        if (width < 1 || width > 65535
+                || height < 1 || height > 65535) {
+            throw new IllegalArgumentException(
+                    "JPEG dimensions must fit unsigned 16-bit values."
+            );
+        }
+
+        byte[] jpeg = createJpeg();
+        for (int index = 0; index < jpeg.length - 9; index++) {
+            if ((jpeg[index] & 0xFF) != 0xFF) {
+                continue;
+            }
+
+            int marker = jpeg[index + 1] & 0xFF;
+            if (marker != 0xC0 && marker != 0xC1 && marker != 0xC2) {
+                continue;
+            }
+
+            jpeg[index + 5] = (byte) (height >>> 8);
+            jpeg[index + 6] = (byte) height;
+            jpeg[index + 7] = (byte) (width >>> 8);
+            jpeg[index + 8] = (byte) width;
+            return jpeg;
+        }
+
+        throw new IllegalStateException(
+                "JPEG start-of-frame marker was not found."
+        );
+    }
+
     private static final class CapturingResultPublisher
             implements RenderResultPublisher {
 
@@ -404,14 +670,48 @@ class RenderHandlerTest {
         }
     }
 
+    private static final class FailOnceResultPublisher
+            implements RenderResultPublisher {
+
+        private final List<RenderResultMessage> messages =
+                new ArrayList<>();
+        private boolean failedOnce;
+
+        @Override
+        public String publish(RenderResultMessage message) {
+            messages.add(message);
+            if (!failedOnce) {
+                failedOnce = true;
+                throw new IllegalStateException(
+                        "fake first result publish failure"
+                );
+            }
+            return "result-message-success";
+        }
+
+        List<RenderResultMessage> messages() {
+            return List.copyOf(messages);
+        }
+    }
+
     private static final class InMemoryObjectStorage
             implements ObjectStorage {
 
         private final Map<String, byte[]> objects = new HashMap<>();
         private final Map<String, byte[]> uploads = new HashMap<>();
+        private String failingUploadSuffix;
+        private int uploadCount;
 
         void put(String objectKey, byte[] bytes) {
             objects.put(objectKey, bytes);
+        }
+
+        void failUploadsEndingWith(String suffix) {
+            this.failingUploadSuffix = suffix;
+        }
+
+        int uploadCount() {
+            return uploadCount;
         }
 
         List<String> uploadedKeys() {
@@ -442,6 +742,9 @@ class RenderHandlerTest {
         ) {
             byte[] bytes = objects.get(objectKey);
             if (bytes == null) {
+                bytes = uploads.get(objectKey);
+            }
+            if (bytes == null) {
                 throw new IllegalStateException(
                         "Missing fake object: " + objectKey
                 );
@@ -462,8 +765,16 @@ class RenderHandlerTest {
                 Path source,
                 String contentType
         ) {
+            if (failingUploadSuffix != null
+                    && objectKey.endsWith(failingUploadSuffix)) {
+                throw new IllegalStateException(
+                        "Fake upload failure: " + objectKey
+                );
+            }
+
             try {
                 uploads.put(objectKey, Files.readAllBytes(source));
+                uploadCount++;
             } catch (IOException exception) {
                 throw new RuntimeException(exception);
             }

--- a/src/main/java/com/chaerok/backend/global/aws/AwsProperties.java
+++ b/src/main/java/com/chaerok/backend/global/aws/AwsProperties.java
@@ -38,6 +38,6 @@ public class AwsProperties {
         private Duration presignedGetExpiration = Duration.ofMinutes(10);
 
         @Min(value = 1, message = "최대 업로드 크기는 1바이트 이상이어야 합니다.")
-        private long maxUploadBytes = 5L * 1024 * 1024;
+        private long maxUploadBytes = 10L * 1024 * 1024;
     }
 }

--- a/src/main/java/com/chaerok/backend/photo/dto/PhotoUploadUrlRequest.java
+++ b/src/main/java/com/chaerok/backend/photo/dto/PhotoUploadUrlRequest.java
@@ -28,8 +28,8 @@ public record PhotoUploadUrlRequest(
 
         @Positive(message = "파일 크기는 1바이트 이상이어야 합니다.")
         @Max(
-                value = 5L * 1024 * 1024,
-                message = "이미지 파일은 최대 5MB까지 업로드할 수 있습니다."
+                value = 10L * 1024 * 1024,
+                message = "이미지 파일은 최대 10MB까지 업로드할 수 있습니다."
         )
         long contentLength,
 

--- a/src/test/java/com/chaerok/backend/global/aws/S3ObjectStorageTest.java
+++ b/src/test/java/com/chaerok/backend/global/aws/S3ObjectStorageTest.java
@@ -54,7 +54,7 @@ class S3ObjectStorageTest {
                 Duration.ofMinutes(10)
         );
         properties.getS3().setMaxUploadBytes(
-                5L * 1024 * 1024
+                10L * 1024 * 1024
         );
 
         objectStorage = new S3ObjectStorage(
@@ -148,7 +148,7 @@ class S3ObjectStorageTest {
                 objectStorage.createPresignedUpload(
                         "users/1/rolls/2/original/001-test.jpg",
                         "image/jpeg",
-                        5L * 1024 * 1024 + 1
+                        10L * 1024 * 1024 + 1
                 )
         ).isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("최대");

--- a/src/test/java/com/chaerok/backend/photo/dto/PhotoUploadUrlRequestTest.java
+++ b/src/test/java/com/chaerok/backend/photo/dto/PhotoUploadUrlRequestTest.java
@@ -1,0 +1,50 @@
+package com.chaerok.backend.photo.dto;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PhotoUploadUrlRequestTest {
+
+    private final Validator validator = Validation
+            .buildDefaultValidatorFactory()
+            .getValidator();
+
+    @Test
+    @DisplayName("10MB JPEG 업로드 요청은 허용한다")
+    void allowsTenMegabyteJpeg() {
+        PhotoUploadUrlRequest request = new PhotoUploadUrlRequest(
+                1,
+                "image/jpeg",
+                10L * 1024 * 1024,
+                LocalDateTime.of(2026, 8, 11, 11, 0)
+        );
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("10MB를 초과한 업로드 요청은 거부한다")
+    void rejectsUploadLargerThanTenMegabytes() {
+        PhotoUploadUrlRequest request = new PhotoUploadUrlRequest(
+                1,
+                "image/jpeg",
+                10L * 1024 * 1024 + 1,
+                LocalDateTime.of(2026, 8, 11, 11, 0)
+        );
+
+        Set<ConstraintViolation<PhotoUploadUrlRequest>> violations =
+                validator.validate(request);
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("이미지 파일은 최대 10MB까지 업로드할 수 있습니다.");
+    }
+}

--- a/src/test/java/com/chaerok/backend/photo/service/PhotoUploadServiceTest.java
+++ b/src/test/java/com/chaerok/backend/photo/service/PhotoUploadServiceTest.java
@@ -241,7 +241,7 @@ class PhotoUploadServiceTest {
         );
 
         when(objectStorage.getMaxUploadBytes())
-                .thenReturn(5L * 1024 * 1024);
+                .thenReturn(10L * 1024 * 1024);
 
         PhotoUploadCompleteResponse response =
                 service.completeUpload(


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 핵심적으로 변경된 사항을 간단히 작성해주세요. -->

-

## 📌 담당 영역
<!-- 해당하는 항목에 체크해주세요. -->

- [ ] 공통 설정 / 인프라
- [ ] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈
<!-- 예: closes #1 -->

-

## 🧩 API / DB 변경 사항
<!-- API, 테이블, 컬럼, Storage 변경이 있으면 작성해주세요. 없으면 "없음" -->

-

## ✅ 테스트

- [ ] 서버 실행 확인
- [ ] Swagger 확인
- [ ] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항
<!-- 리뷰어가 알아야 할 내용이 있다면 작성해주세요. -->

-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 이미지 업로드 및 렌더링 결과 처리의 오류 코드와 재시도 가능 여부를 명확히 제공합니다.
  - 렌더링 단계별 실패 정보를 확인할 수 있습니다.
  - 결과 발행 재시도 시 기존 생성 결과를 재사용합니다.

- **버그 수정**
  - JPEG 형식, 헤더, 이미지 크기와 픽셀 수를 사전에 검증합니다.
  - 생성 파일이 없거나 비어 있는 경우를 감지합니다.
  - 업로드·다운로드·변환 실패를 상황에 맞게 처리합니다.

- **변경 사항**
  - 이미지 업로드 최대 용량이 5MB에서 10MB로 증가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->