### PR TITLE
fix(place): TourAPI 지역 장소 조회 타임아웃 개선

### DIFF
--- a/src/main/java/com/chaerok/backend/place/config/TourApiWarmup.java
+++ b/src/main/java/com/chaerok/backend/place/config/TourApiWarmup.java
@@ -1,0 +1,58 @@
+package com.chaerok.backend.place.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TourApiWarmup {
+
+    private static final Duration WARMUP_TIMEOUT = Duration.ofSeconds(10);
+
+    private final WebClient tourApiWebClient;
+
+    @Value("${external.tour-api.key}")
+    private String serviceKey;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void warmup() {
+        long start = System.currentTimeMillis();
+
+        tourApiWebClient
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/areaBasedList2")
+                        .queryParam("serviceKey", serviceKey)
+                        .queryParam("MobileOS", "ETC")
+                        .queryParam("MobileApp", "Chaerok")
+                        .queryParam("_type", "json")
+                        .queryParam("numOfRows", 1)
+                        .queryParam("pageNo", 1)
+                        .queryParam("arrange", "A")
+                        .queryParam("lDongRegnCd", "44")
+                        .queryParam("lDongSignguCd", "150")
+                        .build())
+                .retrieve()
+                .toBodilessEntity()
+                .timeout(WARMUP_TIMEOUT)
+                .subscribe(
+                        response -> log.info(
+                                "TourAPI warmup completed. elapsed={}ms",
+                                System.currentTimeMillis() - start
+                        ),
+                        error -> log.warn(
+                                "TourAPI warmup failed. elapsed={}ms, message={}",
+                                System.currentTimeMillis() - start,
+                                error.getMessage()
+                        )
+                );
+    }
+}

--- a/src/main/java/com/chaerok/backend/place/config/WebClientConfig.java
+++ b/src/main/java/com/chaerok/backend/place/config/WebClientConfig.java
@@ -2,15 +2,32 @@ package com.chaerok.backend.place.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
 
 @Configuration
 public class WebClientConfig {
 
+    private static final String TOUR_API_BASE_URL =
+            "https://apis.data.go.kr/B551011/KorService2";
+
     @Bean
     public WebClient tourApiWebClient(WebClient.Builder builder) {
+        HttpClient httpClient = HttpClient.create()
+                .metrics(true, uri -> {
+                    int queryIndex = uri.indexOf('?');
+
+                    if (queryIndex >= 0) {
+                        return uri.substring(0, queryIndex);
+                    }
+
+                    return uri;
+                });
+
         return builder
-                .baseUrl("https://apis.data.go.kr/B551011/KorService2")
+                .baseUrl(TOUR_API_BASE_URL)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .build();
     }
 }

--- a/src/main/java/com/chaerok/backend/place/config/WebClientConfig.java
+++ b/src/main/java/com/chaerok/backend/place/config/WebClientConfig.java
@@ -1,0 +1,16 @@
+package com.chaerok.backend.place.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient tourApiWebClient(WebClient.Builder builder) {
+        return builder
+                .baseUrl("https://apis.data.go.kr/B551011/KorService2")
+                .build();
+    }
+}

--- a/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
+++ b/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
@@ -31,6 +31,8 @@ public class TourApiPlaceClient {
             String lDongRegnCd,
             String lDongSignguCd
     ) {
+        long start = System.currentTimeMillis();
+
         try {
             TourApiPlaceResponse response = webClientBuilder
                     .baseUrl(BASE_URL)
@@ -64,16 +66,27 @@ public class TourApiPlaceClient {
             }
 
             return response.getItems();
+
         } catch (WebClientResponseException e) {
             log.warn("TourAPI areaBasedList2 response error. status={}, body={}",
                     e.getStatusCode(), e.getResponseBodyAsString());
             return List.of();
+
         } catch (WebClientRequestException e) {
             log.warn("TourAPI areaBasedList2 request error. message={}", e.getMessage());
             return List.of();
+
         } catch (RuntimeException e) {
             log.error("TourAPI areaBasedList2 unexpected error. message={}", e.getMessage(), e);
             return List.of();
+
+        } finally {
+            log.info(
+                    "TourAPI areaBasedList2 elapsed={}ms, lDongRegnCd={}, lDongSignguCd={}",
+                    System.currentTimeMillis() - start,
+                    lDongRegnCd,
+                    lDongSignguCd
+            );
         }
     }
 

--- a/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
+++ b/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
@@ -16,13 +16,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TourApiPlaceClient {
 
-    private static final String BASE_URL = "https://apis.data.go.kr/B551011/KorService2";
     private static final String AREA_BASED_LIST_PATH = "/areaBasedList2";
     private static final String SEARCH_KEYWORD_PATH = "/searchKeyword2";
     private static final String DETAIL_COMMON_PATH = "/detailCommon2";
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
 
-    private final WebClient.Builder webClientBuilder;
+    private final WebClient tourApiWebClient;
 
     @Value("${external.tour-api.key}")
     private String serviceKey;
@@ -34,9 +33,7 @@ public class TourApiPlaceClient {
         long start = System.currentTimeMillis();
 
         try {
-            TourApiPlaceResponse response = webClientBuilder
-                    .baseUrl(BASE_URL)
-                    .build()
+            TourApiPlaceResponse response = tourApiWebClient
                     .get()
                     .uri(uriBuilder -> uriBuilder
                             .path(AREA_BASED_LIST_PATH)
@@ -60,24 +57,37 @@ public class TourApiPlaceClient {
             }
 
             if (!response.isSuccess()) {
-                log.warn("TourAPI areaBasedList2 failed. lDongRegnCd={}, lDongSignguCd={}",
-                        lDongRegnCd, lDongSignguCd);
+                log.warn(
+                        "TourAPI areaBasedList2 failed. lDongRegnCd={}, lDongSignguCd={}",
+                        lDongRegnCd,
+                        lDongSignguCd
+                );
                 return List.of();
             }
 
             return response.getItems();
 
         } catch (WebClientResponseException e) {
-            log.warn("TourAPI areaBasedList2 response error. status={}, body={}",
-                    e.getStatusCode(), e.getResponseBodyAsString());
+            log.warn(
+                    "TourAPI areaBasedList2 response error. status={}, body={}",
+                    e.getStatusCode(),
+                    e.getResponseBodyAsString()
+            );
             return List.of();
 
         } catch (WebClientRequestException e) {
-            log.warn("TourAPI areaBasedList2 request error. message={}", e.getMessage());
+            log.warn(
+                    "TourAPI areaBasedList2 request error. message={}",
+                    e.getMessage()
+            );
             return List.of();
 
         } catch (RuntimeException e) {
-            log.error("TourAPI areaBasedList2 unexpected error. message={}", e.getMessage(), e);
+            log.error(
+                    "TourAPI areaBasedList2 unexpected error. message={}",
+                    e.getMessage(),
+                    e
+            );
             return List.of();
 
         } finally {
@@ -100,9 +110,7 @@ public class TourApiPlaceClient {
         }
 
         try {
-            TourApiPlaceResponse response = webClientBuilder
-                    .baseUrl(BASE_URL)
-                    .build()
+            TourApiPlaceResponse response = tourApiWebClient
                     .get()
                     .uri(uriBuilder -> uriBuilder
                             .path(SEARCH_KEYWORD_PATH)
@@ -127,23 +135,41 @@ public class TourApiPlaceClient {
             }
 
             if (!response.isSuccess()) {
-                log.warn("TourAPI searchKeyword2 failed. keyword={}, lDongRegnCd={}, lDongSignguCd={}",
-                        keyword, lDongRegnCd, lDongSignguCd);
+                log.warn(
+                        "TourAPI searchKeyword2 failed. keyword={}, lDongRegnCd={}, lDongSignguCd={}",
+                        keyword,
+                        lDongRegnCd,
+                        lDongSignguCd
+                );
                 return List.of();
             }
 
             return response.getItems();
+
         } catch (WebClientResponseException e) {
-            log.warn("TourAPI searchKeyword2 response error. keyword={}, status={}, body={}",
-                    keyword, e.getStatusCode(), e.getResponseBodyAsString());
+            log.warn(
+                    "TourAPI searchKeyword2 response error. keyword={}, status={}, body={}",
+                    keyword,
+                    e.getStatusCode(),
+                    e.getResponseBodyAsString()
+            );
             return List.of();
+
         } catch (WebClientRequestException e) {
-            log.warn("TourAPI searchKeyword2 request error. keyword={}, message={}",
-                    keyword, e.getMessage());
+            log.warn(
+                    "TourAPI searchKeyword2 request error. keyword={}, message={}",
+                    keyword,
+                    e.getMessage()
+            );
             return List.of();
+
         } catch (RuntimeException e) {
-            log.error("TourAPI searchKeyword2 unexpected error. keyword={}, message={}",
-                    keyword, e.getMessage(), e);
+            log.error(
+                    "TourAPI searchKeyword2 unexpected error. keyword={}, message={}",
+                    keyword,
+                    e.getMessage(),
+                    e
+            );
             return List.of();
         }
     }
@@ -154,9 +180,7 @@ public class TourApiPlaceClient {
         }
 
         try {
-            TourApiPlaceResponse response = webClientBuilder
-                    .baseUrl(BASE_URL)
-                    .build()
+            TourApiPlaceResponse response = tourApiWebClient
                     .get()
                     .uri(uriBuilder -> uriBuilder
                             .path(DETAIL_COMMON_PATH)
@@ -179,7 +203,7 @@ public class TourApiPlaceClient {
 
             if (!response.isSuccess()) {
                 log.warn(
-                        "TourAPI detailCommon2 failed. contentId={}, resultCode={}, resultMsg={}",
+                        "TourAPI detailCommon2 failed. contentId={}",
                         contentId
                 );
                 return null;

--- a/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
+++ b/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
@@ -30,8 +30,6 @@ public class TourApiPlaceClient {
             String lDongRegnCd,
             String lDongSignguCd
     ) {
-        long start = System.currentTimeMillis();
-
         try {
             TourApiPlaceResponse response = tourApiWebClient
                     .get()
@@ -89,14 +87,6 @@ public class TourApiPlaceClient {
                     e
             );
             return List.of();
-
-        } finally {
-            log.info(
-                    "TourAPI areaBasedList2 elapsed={}ms, lDongRegnCd={}, lDongSignguCd={}",
-                    System.currentTimeMillis() - start,
-                    lDongRegnCd,
-                    lDongSignguCd
-            );
         }
     }
 

--- a/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
+++ b/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
@@ -56,9 +56,11 @@ public class TourApiPlaceClient {
 
             if (!response.isSuccess()) {
                 log.warn(
-                        "TourAPI areaBasedList2 failed. lDongRegnCd={}, lDongSignguCd={}",
+                        "TourAPI areaBasedList2 failed. lDongRegnCd={}, lDongSignguCd={}, resultCode={}, resultMsg={}",
                         lDongRegnCd,
-                        lDongSignguCd
+                        lDongSignguCd,
+                        response.getResultCode(),
+                        response.getResultMsg()
                 );
                 return List.of();
             }
@@ -126,10 +128,12 @@ public class TourApiPlaceClient {
 
             if (!response.isSuccess()) {
                 log.warn(
-                        "TourAPI searchKeyword2 failed. keyword={}, lDongRegnCd={}, lDongSignguCd={}",
+                        "TourAPI searchKeyword2 failed. keyword={}, lDongRegnCd={}, lDongSignguCd={}, resultCode={}, resultMsg={}",
                         keyword,
                         lDongRegnCd,
-                        lDongSignguCd
+                        lDongSignguCd,
+                        response.getResultCode(),
+                        response.getResultMsg()
                 );
                 return List.of();
             }
@@ -193,8 +197,10 @@ public class TourApiPlaceClient {
 
             if (!response.isSuccess()) {
                 log.warn(
-                        "TourAPI detailCommon2 failed. contentId={}",
-                        contentId
+                        "TourAPI detailCommon2 failed. contentId={}, resultCode={}, resultMsg={}",
+                        contentId,
+                        response.getResultCode(),
+                        response.getResultMsg()
                 );
                 return null;
             }

--- a/src/main/java/com/chaerok/backend/place/external/TourApiPlaceResponse.java
+++ b/src/main/java/com/chaerok/backend/place/external/TourApiPlaceResponse.java
@@ -29,6 +29,22 @@ public record TourApiPlaceResponse(
                 && "0000".equals(response.header().resultCode());
     }
 
+    public String getResultCode() {
+        if (response == null || response.header() == null) {
+            return null;
+        }
+
+        return response.header().resultCode();
+    }
+
+    public String getResultMsg() {
+        if (response == null || response.header() == null) {
+            return null;
+        }
+
+        return response.header().resultMsg();
+    }
+
     public record Response(
             @JsonProperty("header")
             Header header,


### PR DESCRIPTION
## ✨ 변경 사항

- TourAPI 지역 장소 조회 시 최초 외부 연결 지연으로 발생하던 5초 timeout 문제 개선
- TourAPI 전용 `WebClient` Bean 구성 및 재사용 구조 적용
- Reactor Netty HTTP Client Metrics 활성화
- 애플리케이션 기동 완료 후 TourAPI 비동기 warm-up 요청 추가
- 원인 분석을 위해 추가했던 임시 응답시간 측정 로그 제거

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #52 

## 🧩 API / DB 변경 사항

- API 경로 및 응답 형식 변경 없음
- DB 변경 없음
- `GET /api/places/external`의 TourAPI 호출 구조 개선

## ✅ 테스트

- [x] 서버 실행 확인
- [x] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- Render 환경에서 TourAPI 최초 호출 시 약 5.8~6.3초가 소요되어 기존 5초 timeout이 반복적으로 발생함
- Reactor Netty Metrics 측정 결과 최초 연결 시 DNS 약 1.6초, TLS handshake 약 2.2초가 소요되는 것을 확인함
- WebClient 재사용만 적용한 경우에도 최초 호출 timeout이 동일하게 재현됨
- 비동기 TourAPI warm-up 적용 후 실제 첫 `GET /api/places/external` 요청이 약 787ms로 감소했으며, 이후 요청은 약 190~270ms 수준으로 안정화됨
- warm-up은 비동기로 수행하여 애플리케이션 기동 및 health check 응답을 차단하지 않도록 처리함
- 기존 TourAPI 요청 timeout 5초는 유지함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 애플리케이션 시작 시 관광지 정보 서비스 연결을 자동으로 확인합니다.
  * 관광지 지역 조회, 키워드 검색, 상세 정보 요청을 보다 안정적으로 처리합니다.
* **개선 사항**
  * 외부 관광 정보 서비스 요청에 타임아웃을 적용해 응답 지연을 줄였습니다.
  * 서비스 연결 결과와 오류 상황을 확인하기 쉬운 형태로 기록합니다.
  * 요청 성능 지표를 경로 기준으로 집계해 운영 모니터링을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->