### PR TITLE
feat(place): 지역 장소 목록 TourAPI 조회 구조 개선

### DIFF
--- a/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
+++ b/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
@@ -25,7 +25,6 @@ public class TourApiPlaceClient {
     private static final String DETAIL_COMMON_PATH = "/detailCommon2";
 
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
-
     private static final int AREA_PAGE_SIZE = 50;
 
     private final WebClient tourApiWebClient;
@@ -95,8 +94,6 @@ public class TourApiPlaceClient {
             return Map.of();
         }
 
-        long start = System.currentTimeMillis();
-
         Map<String, TourApiPlaceItem> matchedPlaces = new HashMap<>();
         Set<String> remainingContentIds = new HashSet<>(targetContentIds);
 
@@ -104,8 +101,6 @@ public class TourApiPlaceClient {
 
         try {
             while (!remainingContentIds.isEmpty()) {
-                long pageStart = System.currentTimeMillis();
-
                 TourApiPlaceResponse response = requestPlacesByRegionPage(
                         lDongRegnCd,
                         lDongSignguCd,
@@ -137,14 +132,6 @@ public class TourApiPlaceClient {
                         matchedPlaces.put(item.contentId(), item);
                     }
                 }
-
-                log.info(
-                        "TourAPI areaBasedList2 page elapsed={}ms, pageNo={}, matchedCount={}, remainingCount={}",
-                        System.currentTimeMillis() - pageStart,
-                        pageNo,
-                        matchedPlaces.size(),
-                        remainingContentIds.size()
-                );
 
                 if (remainingContentIds.isEmpty()) {
                     break;
@@ -183,15 +170,6 @@ public class TourApiPlaceClient {
                     e
             );
             return matchedPlaces;
-
-        } finally {
-            log.info(
-                    "TourAPI representative matching elapsed={}ms, targetCount={}, matchedCount={}, pages={}",
-                    System.currentTimeMillis() - start,
-                    targetContentIds.size(),
-                    matchedPlaces.size(),
-                    pageNo
-            );
         }
     }
 

--- a/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
+++ b/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
@@ -173,6 +173,8 @@ public class TourApiPlaceClient {
             return null;
         }
 
+        long start = System.currentTimeMillis();
+
         try {
             TourApiPlaceResponse response = tourApiWebClient
                     .get()
@@ -234,6 +236,13 @@ public class TourApiPlaceClient {
                     e
             );
             return null;
+
+        } finally {
+            log.info(
+                    "TourAPI detailCommon2 elapsed={}ms, contentId={}",
+                    System.currentTimeMillis() - start,
+                    contentId
+            );
         }
     }
 }

--- a/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
+++ b/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
@@ -9,7 +9,11 @@ import org.springframework.web.reactive.function.client.WebClientRequestExceptio
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Slf4j
 @Component
@@ -19,7 +23,10 @@ public class TourApiPlaceClient {
     private static final String AREA_BASED_LIST_PATH = "/areaBasedList2";
     private static final String SEARCH_KEYWORD_PATH = "/searchKeyword2";
     private static final String DETAIL_COMMON_PATH = "/detailCommon2";
+
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+    private static final int AREA_PAGE_SIZE = 50;
 
     private final WebClient tourApiWebClient;
 
@@ -31,24 +38,11 @@ public class TourApiPlaceClient {
             String lDongSignguCd
     ) {
         try {
-            TourApiPlaceResponse response = tourApiWebClient
-                    .get()
-                    .uri(uriBuilder -> uriBuilder
-                            .path(AREA_BASED_LIST_PATH)
-                            .queryParam("serviceKey", serviceKey)
-                            .queryParam("MobileOS", "ETC")
-                            .queryParam("MobileApp", "Chaerok")
-                            .queryParam("_type", "json")
-                            .queryParam("numOfRows", 50)
-                            .queryParam("pageNo", 1)
-                            .queryParam("arrange", "A")
-                            .queryParam("lDongRegnCd", lDongRegnCd)
-                            .queryParam("lDongSignguCd", lDongSignguCd)
-                            .build())
-                    .retrieve()
-                    .bodyToMono(TourApiPlaceResponse.class)
-                    .timeout(REQUEST_TIMEOUT)
-                    .block();
+            TourApiPlaceResponse response = requestPlacesByRegionPage(
+                    lDongRegnCd,
+                    lDongSignguCd,
+                    1
+            );
 
             if (response == null) {
                 return List.of();
@@ -90,6 +84,140 @@ public class TourApiPlaceClient {
             );
             return List.of();
         }
+    }
+
+    public Map<String, TourApiPlaceItem> getPlacesByContentIds(
+            String lDongRegnCd,
+            String lDongSignguCd,
+            Set<String> targetContentIds
+    ) {
+        if (targetContentIds == null || targetContentIds.isEmpty()) {
+            return Map.of();
+        }
+
+        long start = System.currentTimeMillis();
+
+        Map<String, TourApiPlaceItem> matchedPlaces = new HashMap<>();
+        Set<String> remainingContentIds = new HashSet<>(targetContentIds);
+
+        int pageNo = 1;
+
+        try {
+            while (!remainingContentIds.isEmpty()) {
+                long pageStart = System.currentTimeMillis();
+
+                TourApiPlaceResponse response = requestPlacesByRegionPage(
+                        lDongRegnCd,
+                        lDongSignguCd,
+                        pageNo
+                );
+
+                if (response == null) {
+                    break;
+                }
+
+                if (!response.isSuccess()) {
+                    log.warn(
+                            "TourAPI areaBasedList2 failed while matching. pageNo={}, resultCode={}, resultMsg={}",
+                            pageNo,
+                            response.getResultCode(),
+                            response.getResultMsg()
+                    );
+                    break;
+                }
+
+                List<TourApiPlaceItem> items = response.getItems();
+
+                for (TourApiPlaceItem item : items) {
+                    if (item.contentId() == null) {
+                        continue;
+                    }
+
+                    if (remainingContentIds.remove(item.contentId())) {
+                        matchedPlaces.put(item.contentId(), item);
+                    }
+                }
+
+                log.info(
+                        "TourAPI areaBasedList2 page elapsed={}ms, pageNo={}, matchedCount={}, remainingCount={}",
+                        System.currentTimeMillis() - pageStart,
+                        pageNo,
+                        matchedPlaces.size(),
+                        remainingContentIds.size()
+                );
+
+                if (remainingContentIds.isEmpty()) {
+                    break;
+                }
+
+                int totalCount = response.getTotalCount();
+
+                if (items.isEmpty() || totalCount <= pageNo * AREA_PAGE_SIZE) {
+                    break;
+                }
+
+                pageNo++;
+            }
+
+            return matchedPlaces;
+
+        } catch (WebClientResponseException e) {
+            log.warn(
+                    "TourAPI areaBasedList2 matching response error. status={}, body={}",
+                    e.getStatusCode(),
+                    e.getResponseBodyAsString()
+            );
+            return matchedPlaces;
+
+        } catch (WebClientRequestException e) {
+            log.warn(
+                    "TourAPI areaBasedList2 matching request error. message={}",
+                    e.getMessage()
+            );
+            return matchedPlaces;
+
+        } catch (RuntimeException e) {
+            log.error(
+                    "TourAPI areaBasedList2 matching unexpected error. message={}",
+                    e.getMessage(),
+                    e
+            );
+            return matchedPlaces;
+
+        } finally {
+            log.info(
+                    "TourAPI representative matching elapsed={}ms, targetCount={}, matchedCount={}, pages={}",
+                    System.currentTimeMillis() - start,
+                    targetContentIds.size(),
+                    matchedPlaces.size(),
+                    pageNo
+            );
+        }
+    }
+
+    private TourApiPlaceResponse requestPlacesByRegionPage(
+            String lDongRegnCd,
+            String lDongSignguCd,
+            int pageNo
+    ) {
+        return tourApiWebClient
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(AREA_BASED_LIST_PATH)
+                        .queryParam("serviceKey", serviceKey)
+                        .queryParam("MobileOS", "ETC")
+                        .queryParam("MobileApp", "Chaerok")
+                        .queryParam("_type", "json")
+                        .queryParam("numOfRows", AREA_PAGE_SIZE)
+                        .queryParam("pageNo", pageNo)
+                        .queryParam("arrange", "A")
+                        .queryParam("lDongRegnCd", lDongRegnCd)
+                        .queryParam("lDongSignguCd", lDongSignguCd)
+                        .build())
+                .retrieve()
+                .bodyToMono(TourApiPlaceResponse.class)
+                .timeout(REQUEST_TIMEOUT)
+                .block();
     }
 
     public List<TourApiPlaceItem> searchPlacesByKeyword(
@@ -173,8 +301,6 @@ public class TourApiPlaceClient {
             return null;
         }
 
-        long start = System.currentTimeMillis();
-
         try {
             TourApiPlaceResponse response = tourApiWebClient
                     .get()
@@ -236,13 +362,6 @@ public class TourApiPlaceClient {
                     e
             );
             return null;
-
-        } finally {
-            log.info(
-                    "TourAPI detailCommon2 elapsed={}ms, contentId={}",
-                    System.currentTimeMillis() - start,
-                    contentId
-            );
         }
     }
 }

--- a/src/main/java/com/chaerok/backend/place/external/TourApiPlaceResponse.java
+++ b/src/main/java/com/chaerok/backend/place/external/TourApiPlaceResponse.java
@@ -45,6 +45,16 @@ public record TourApiPlaceResponse(
         return response.header().resultMsg();
     }
 
+    public int getTotalCount() {
+        if (response == null
+                || response.body() == null
+                || response.body().totalCount() == null) {
+            return 0;
+        }
+
+        return response.body().totalCount();
+    }
+
     public record Response(
             @JsonProperty("header")
             Header header,

--- a/src/main/java/com/chaerok/backend/place/service/PlaceService.java
+++ b/src/main/java/com/chaerok/backend/place/service/PlaceService.java
@@ -11,7 +11,6 @@ import com.chaerok.backend.place.repository.PlaceRepository;
 import com.chaerok.backend.region.entity.Region;
 import com.chaerok.backend.region.repository.RegionRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +19,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -31,75 +29,30 @@ public class PlaceService {
     private final TourApiPlaceClient tourApiPlaceClient;
 
     public List<PlaceListResponse> getPlacesByRegion(Long regionId) {
-        long totalStart = System.currentTimeMillis();
+        Region region = regionRepository.findById(regionId)
+                .orElseThrow(RegionNotFoundException::new);
 
-        try {
-            long regionStart = System.currentTimeMillis();
+        List<Place> representativePlaces =
+                placeRepository.findByRegionIdAndRepresentativeTrue(regionId);
 
-            Region region = regionRepository.findById(regionId)
-                    .orElseThrow(RegionNotFoundException::new);
+        Set<String> targetContentIds = representativePlaces.stream()
+                .map(Place::getTourContentId)
+                .filter(contentId -> contentId != null && !contentId.isBlank())
+                .collect(Collectors.toSet());
 
-            log.info(
-                    "Place list region query elapsed={}ms, regionId={}",
-                    System.currentTimeMillis() - regionStart,
-                    regionId
-            );
+        Map<String, TourApiPlaceItem> tourApiPlaces =
+                tourApiPlaceClient.getPlacesByContentIds(
+                        region.getLdongRegnCd(),
+                        region.getLdongSignguCd(),
+                        targetContentIds
+                );
 
-            long placeQueryStart = System.currentTimeMillis();
-
-            List<Place> representativePlaces =
-                    placeRepository.findByRegionIdAndRepresentativeTrue(regionId);
-
-            log.info(
-                    "Place list DB query elapsed={}ms, representativeCount={}, regionId={}",
-                    System.currentTimeMillis() - placeQueryStart,
-                    representativePlaces.size(),
-                    regionId
-            );
-
-            Set<String> targetContentIds = representativePlaces.stream()
-                    .map(Place::getTourContentId)
-                    .filter(contentId -> contentId != null && !contentId.isBlank())
-                    .collect(Collectors.toSet());
-
-            log.info(
-                    "Place list TourAPI target count={}, totalCount={}, regionId={}",
-                    targetContentIds.size(),
-                    representativePlaces.size(),
-                    regionId
-            );
-
-            long tourApiStart = System.currentTimeMillis();
-
-            Map<String, TourApiPlaceItem> tourApiPlaces =
-                    tourApiPlaceClient.getPlacesByContentIds(
-                            region.getLdongRegnCd(),
-                            region.getLdongSignguCd(),
-                            targetContentIds
-                    );
-
-            log.info(
-                    "Place list TourAPI matching elapsed={}ms, targetCount={}, matchedCount={}, regionId={}",
-                    System.currentTimeMillis() - tourApiStart,
-                    targetContentIds.size(),
-                    tourApiPlaces.size(),
-                    regionId
-            );
-
-            return representativePlaces.stream()
-                    .map(place -> toPlaceListResponse(
-                            place,
-                            tourApiPlaces.get(place.getTourContentId())
-                    ))
-                    .toList();
-
-        } finally {
-            log.info(
-                    "Place list total elapsed={}ms, regionId={}",
-                    System.currentTimeMillis() - totalStart,
-                    regionId
-            );
-        }
+        return representativePlaces.stream()
+                .map(place -> toPlaceListResponse(
+                        place,
+                        tourApiPlaces.get(place.getTourContentId())
+                ))
+                .toList();
     }
 
     public List<PlaceListResponse> getExternalPlaces(Long regionId) {

--- a/src/main/java/com/chaerok/backend/place/service/PlaceService.java
+++ b/src/main/java/com/chaerok/backend/place/service/PlaceService.java
@@ -16,6 +16,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -31,15 +34,14 @@ public class PlaceService {
         long totalStart = System.currentTimeMillis();
 
         try {
-            long regionCheckStart = System.currentTimeMillis();
+            long regionStart = System.currentTimeMillis();
 
-            if (!regionRepository.existsById(regionId)) {
-                throw new RegionNotFoundException();
-            }
+            Region region = regionRepository.findById(regionId)
+                    .orElseThrow(RegionNotFoundException::new);
 
             log.info(
-                    "Place list region check elapsed={}ms, regionId={}",
-                    System.currentTimeMillis() - regionCheckStart,
+                    "Place list region query elapsed={}ms, regionId={}",
+                    System.currentTimeMillis() - regionStart,
                     regionId
             );
 
@@ -55,31 +57,41 @@ public class PlaceService {
                     regionId
             );
 
-            long tourApiTargetCount = representativePlaces.stream()
-                    .filter(place -> place.getTourContentId() != null)
-                    .filter(place -> !place.getTourContentId().isBlank())
-                    .count();
+            Set<String> targetContentIds = representativePlaces.stream()
+                    .map(Place::getTourContentId)
+                    .filter(contentId -> contentId != null && !contentId.isBlank())
+                    .collect(Collectors.toSet());
 
             log.info(
                     "Place list TourAPI target count={}, totalCount={}, regionId={}",
-                    tourApiTargetCount,
+                    targetContentIds.size(),
                     representativePlaces.size(),
                     regionId
             );
 
             long tourApiStart = System.currentTimeMillis();
 
-            List<PlaceListResponse> result = representativePlaces.stream()
-                    .map(this::toPlaceListResponseWithTourApi)
-                    .toList();
+            Map<String, TourApiPlaceItem> tourApiPlaces =
+                    tourApiPlaceClient.getPlacesByContentIds(
+                            region.getLdongRegnCd(),
+                            region.getLdongSignguCd(),
+                            targetContentIds
+                    );
 
             log.info(
-                    "Place list TourAPI total elapsed={}ms, regionId={}",
+                    "Place list TourAPI matching elapsed={}ms, targetCount={}, matchedCount={}, regionId={}",
                     System.currentTimeMillis() - tourApiStart,
+                    targetContentIds.size(),
+                    tourApiPlaces.size(),
                     regionId
             );
 
-            return result;
+            return representativePlaces.stream()
+                    .map(place -> toPlaceListResponse(
+                            place,
+                            tourApiPlaces.get(place.getTourContentId())
+                    ))
+                    .toList();
 
         } finally {
             log.info(
@@ -102,9 +114,10 @@ public class PlaceService {
                 .toList();
     }
 
-    private PlaceListResponse toPlaceListResponseWithTourApi(Place place) {
-        TourApiPlaceItem tourApiItem = tourApiPlaceClient.getPlaceDetail(place.getTourContentId());
-
+    private PlaceListResponse toPlaceListResponse(
+            Place place,
+            TourApiPlaceItem tourApiItem
+    ) {
         if (tourApiItem == null) {
             return PlaceListResponse.from(place);
         }
@@ -116,7 +129,8 @@ public class PlaceService {
         Place place = placeRepository.findById(placeId)
                 .orElseThrow(PlaceNotFoundException::new);
 
-        TourApiPlaceItem tourApiItem = tourApiPlaceClient.getPlaceDetail(place.getTourContentId());
+        TourApiPlaceItem tourApiItem =
+                tourApiPlaceClient.getPlaceDetail(place.getTourContentId());
 
         if (tourApiItem == null) {
             return PlaceDetailResponse.from(place);

--- a/src/main/java/com/chaerok/backend/place/service/PlaceService.java
+++ b/src/main/java/com/chaerok/backend/place/service/PlaceService.java
@@ -11,11 +11,13 @@ import com.chaerok.backend.place.repository.PlaceRepository;
 import com.chaerok.backend.region.entity.Region;
 import com.chaerok.backend.region.repository.RegionRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -26,16 +28,33 @@ public class PlaceService {
     private final TourApiPlaceClient tourApiPlaceClient;
 
     public List<PlaceListResponse> getPlacesByRegion(Long regionId) {
-        if (!regionRepository.existsById(regionId)) {
-            throw new RegionNotFoundException();
+        long start = System.currentTimeMillis();
+
+        try {
+            if (!regionRepository.existsById(regionId)) {
+                throw new RegionNotFoundException();
+            }
+
+            List<Place> representativePlaces =
+                    placeRepository.findByRegionIdAndRepresentativeTrue(regionId);
+
+            log.info(
+                    "Place list representative count={}, regionId={}",
+                    representativePlaces.size(),
+                    regionId
+            );
+
+            return representativePlaces.stream()
+                    .map(this::toPlaceListResponseWithTourApi)
+                    .toList();
+
+        } finally {
+            log.info(
+                    "Place list elapsed={}ms, regionId={}",
+                    System.currentTimeMillis() - start,
+                    regionId
+            );
         }
-
-        List<Place> representativePlaces =
-                placeRepository.findByRegionIdAndRepresentativeTrue(regionId);
-
-        return representativePlaces.stream()
-                .map(this::toPlaceListResponseWithTourApi)
-                .toList();
     }
 
     public List<PlaceListResponse> getExternalPlaces(Long regionId) {

--- a/src/main/java/com/chaerok/backend/place/service/PlaceService.java
+++ b/src/main/java/com/chaerok/backend/place/service/PlaceService.java
@@ -28,30 +28,63 @@ public class PlaceService {
     private final TourApiPlaceClient tourApiPlaceClient;
 
     public List<PlaceListResponse> getPlacesByRegion(Long regionId) {
-        long start = System.currentTimeMillis();
+        long totalStart = System.currentTimeMillis();
 
         try {
+            long regionCheckStart = System.currentTimeMillis();
+
             if (!regionRepository.existsById(regionId)) {
                 throw new RegionNotFoundException();
             }
+
+            log.info(
+                    "Place list region check elapsed={}ms, regionId={}",
+                    System.currentTimeMillis() - regionCheckStart,
+                    regionId
+            );
+
+            long placeQueryStart = System.currentTimeMillis();
 
             List<Place> representativePlaces =
                     placeRepository.findByRegionIdAndRepresentativeTrue(regionId);
 
             log.info(
-                    "Place list representative count={}, regionId={}",
+                    "Place list DB query elapsed={}ms, representativeCount={}, regionId={}",
+                    System.currentTimeMillis() - placeQueryStart,
                     representativePlaces.size(),
                     regionId
             );
 
-            return representativePlaces.stream()
+            long tourApiTargetCount = representativePlaces.stream()
+                    .filter(place -> place.getTourContentId() != null)
+                    .filter(place -> !place.getTourContentId().isBlank())
+                    .count();
+
+            log.info(
+                    "Place list TourAPI target count={}, totalCount={}, regionId={}",
+                    tourApiTargetCount,
+                    representativePlaces.size(),
+                    regionId
+            );
+
+            long tourApiStart = System.currentTimeMillis();
+
+            List<PlaceListResponse> result = representativePlaces.stream()
                     .map(this::toPlaceListResponseWithTourApi)
                     .toList();
 
+            log.info(
+                    "Place list TourAPI total elapsed={}ms, regionId={}",
+                    System.currentTimeMillis() - tourApiStart,
+                    regionId
+            );
+
+            return result;
+
         } finally {
             log.info(
-                    "Place list elapsed={}ms, regionId={}",
-                    System.currentTimeMillis() - start,
+                    "Place list total elapsed={}ms, regionId={}",
+                    System.currentTimeMillis() - totalStart,
                     regionId
             );
         }

--- a/src/test/java/com/chaerok/backend/place/service/PlaceServiceTest.java
+++ b/src/test/java/com/chaerok/backend/place/service/PlaceServiceTest.java
@@ -22,7 +22,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -65,60 +67,107 @@ class PlaceServiceTest {
         // given
         Long regionId = 1L;
 
-        when(regionRepository.existsById(regionId)).thenReturn(true);
-        when(placeRepository.findByRegionIdAndRepresentativeTrue(regionId)).thenReturn(List.of(place));
+        when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
+        when(region.getLdongRegnCd()).thenReturn("44");
+        when(region.getLdongSignguCd()).thenReturn("150");
+
+        when(placeRepository.findByRegionIdAndRepresentativeTrue(regionId))
+                .thenReturn(List.of(place));
+
         mockPlaceForListResponse();
 
         TourApiPlaceItem tourApiItem = createTourApiPlaceItem();
-        when(tourApiPlaceClient.getPlaceDetail("1001")).thenReturn(tourApiItem);
+
+        when(tourApiPlaceClient.getPlacesByContentIds(
+                "44",
+                "150",
+                Set.of("1001")
+        )).thenReturn(Map.of(
+                "1001",
+                tourApiItem
+        ));
 
         // when
-        List<PlaceListResponse> responses = placeService.getPlacesByRegion(regionId);
+        List<PlaceListResponse> responses =
+                placeService.getPlacesByRegion(regionId);
 
         // then
         assertThat(responses).hasSize(1);
         assertThat(responses.get(0).id()).isEqualTo(1L);
         assertThat(responses.get(0).tourContentId()).isEqualTo("1001");
         assertThat(responses.get(0).title()).isEqualTo("TourAPI 공산성");
-        assertThat(responses.get(0).address()).isEqualTo("TourAPI 충청남도 공주시 웅진로 280");
-        assertThat(responses.get(0).latitude()).isEqualByComparingTo(new BigDecimal("36.4623000"));
-        assertThat(responses.get(0).longitude()).isEqualByComparingTo(new BigDecimal("127.1248000"));
-        assertThat(responses.get(0).firstImageUrl()).isEqualTo("https://tour-api.example.com/image.jpg");
-        assertThat(responses.get(0).categoryGroup()).isEqualTo(PlaceCategoryGroup.TOURISM);
-        assertThat(responses.get(0).categoryDetail()).isEqualTo(PlaceCategoryDetail.HERITAGE);
+        assertThat(responses.get(0).address())
+                .isEqualTo("TourAPI 충청남도 공주시 웅진로 280");
+        assertThat(responses.get(0).latitude())
+                .isEqualByComparingTo(new BigDecimal("36.4623000"));
+        assertThat(responses.get(0).longitude())
+                .isEqualByComparingTo(new BigDecimal("127.1248000"));
+        assertThat(responses.get(0).firstImageUrl())
+                .isEqualTo("https://tour-api.example.com/image.jpg");
+        assertThat(responses.get(0).categoryGroup())
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(responses.get(0).categoryDetail())
+                .isEqualTo(PlaceCategoryDetail.HERITAGE);
 
-        verify(regionRepository).existsById(regionId);
-        verify(placeRepository).findByRegionIdAndRepresentativeTrue(regionId);
-        verify(tourApiPlaceClient).getPlaceDetail("1001");
+        verify(regionRepository).findById(regionId);
+        verify(placeRepository)
+                .findByRegionIdAndRepresentativeTrue(regionId);
+
+        verify(tourApiPlaceClient).getPlacesByContentIds(
+                "44",
+                "150",
+                Set.of("1001")
+        );
     }
 
     @Test
-    @DisplayName("TourAPI 상세 조회 결과가 없으면 DB 장소 정보로 대표 장소 목록을 반환한다")
+    @DisplayName("TourAPI 매칭 결과가 없으면 DB 장소 정보로 대표 장소 목록을 반환한다")
     void getPlacesByRegionWithTourApiFallback() {
         // given
         Long regionId = 1L;
 
-        when(regionRepository.existsById(regionId)).thenReturn(true);
-        when(placeRepository.findByRegionIdAndRepresentativeTrue(regionId)).thenReturn(List.of(place));
+        when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
+        when(region.getLdongRegnCd()).thenReturn("44");
+        when(region.getLdongSignguCd()).thenReturn("150");
+
+        when(placeRepository.findByRegionIdAndRepresentativeTrue(regionId))
+                .thenReturn(List.of(place));
+
         mockPlaceForListResponse();
-        when(tourApiPlaceClient.getPlaceDetail("1001")).thenReturn(null);
+
+        when(tourApiPlaceClient.getPlacesByContentIds(
+                "44",
+                "150",
+                Set.of("1001")
+        )).thenReturn(Map.of());
 
         // when
-        List<PlaceListResponse> responses = placeService.getPlacesByRegion(regionId);
+        List<PlaceListResponse> responses =
+                placeService.getPlacesByRegion(regionId);
 
         // then
         assertThat(responses).hasSize(1);
         assertThat(responses.get(0).id()).isEqualTo(1L);
         assertThat(responses.get(0).tourContentId()).isEqualTo("1001");
         assertThat(responses.get(0).title()).isEqualTo("공산성");
-        assertThat(responses.get(0).address()).isEqualTo("충청남도 공주시 웅진로 280");
-        assertThat(responses.get(0).firstImageUrl()).isEqualTo("https://example.com/image.jpg");
-        assertThat(responses.get(0).categoryGroup()).isEqualTo(PlaceCategoryGroup.TOURISM);
-        assertThat(responses.get(0).categoryDetail()).isEqualTo(PlaceCategoryDetail.HERITAGE);
+        assertThat(responses.get(0).address())
+                .isEqualTo("충청남도 공주시 웅진로 280");
+        assertThat(responses.get(0).firstImageUrl())
+                .isEqualTo("https://example.com/image.jpg");
+        assertThat(responses.get(0).categoryGroup())
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(responses.get(0).categoryDetail())
+                .isEqualTo(PlaceCategoryDetail.HERITAGE);
 
-        verify(regionRepository).existsById(regionId);
-        verify(placeRepository).findByRegionIdAndRepresentativeTrue(regionId);
-        verify(tourApiPlaceClient).getPlaceDetail("1001");
+        verify(regionRepository).findById(regionId);
+        verify(placeRepository)
+                .findByRegionIdAndRepresentativeTrue(regionId);
+
+        verify(tourApiPlaceClient).getPlacesByContentIds(
+                "44",
+                "150",
+                Set.of("1001")
+        );
     }
 
     @Test
@@ -127,14 +176,15 @@ class PlaceServiceTest {
         // given
         Long regionId = 999L;
 
-        when(regionRepository.existsById(regionId)).thenReturn(false);
+        when(regionRepository.findById(regionId))
+                .thenReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> placeService.getPlacesByRegion(regionId))
                 .isInstanceOf(RegionNotFoundException.class)
                 .hasMessage("지역을 찾을 수 없습니다.");
 
-        verify(regionRepository).existsById(regionId);
+        verify(regionRepository).findById(regionId);
         verifyNoInteractions(placeRepository);
         verifyNoInteractions(tourApiPlaceClient);
     }
@@ -145,26 +195,37 @@ class PlaceServiceTest {
         // given
         Long placeId = 1L;
 
-        when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
+        when(placeRepository.findById(placeId))
+                .thenReturn(Optional.of(place));
+
         mockPlaceForDetailResponse();
 
         TourApiPlaceItem tourApiItem = createTourApiPlaceItem();
-        when(tourApiPlaceClient.getPlaceDetail("1001")).thenReturn(tourApiItem);
+
+        when(tourApiPlaceClient.getPlaceDetail("1001"))
+                .thenReturn(tourApiItem);
 
         // when
-        PlaceDetailResponse response = placeService.getPlace(placeId);
+        PlaceDetailResponse response =
+                placeService.getPlace(placeId);
 
         // then
         assertThat(response.id()).isEqualTo(1L);
         assertThat(response.regionId()).isEqualTo(1L);
         assertThat(response.tourContentId()).isEqualTo("1001");
         assertThat(response.title()).isEqualTo("TourAPI 공산성");
-        assertThat(response.address()).isEqualTo("TourAPI 충청남도 공주시 웅진로 280");
-        assertThat(response.firstImageUrl()).isEqualTo("https://tour-api.example.com/image.jpg");
-        assertThat(response.overview()).isEqualTo("TourAPI 공산성 소개 문구입니다.");
-        assertThat(response.categoryGroup()).isEqualTo(PlaceCategoryGroup.TOURISM);
-        assertThat(response.categoryDetail()).isEqualTo(PlaceCategoryDetail.HERITAGE);
-        assertThat(response.source()).isEqualTo(PlaceSource.TOUR_API);
+        assertThat(response.address())
+                .isEqualTo("TourAPI 충청남도 공주시 웅진로 280");
+        assertThat(response.firstImageUrl())
+                .isEqualTo("https://tour-api.example.com/image.jpg");
+        assertThat(response.overview())
+                .isEqualTo("TourAPI 공산성 소개 문구입니다.");
+        assertThat(response.categoryGroup())
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(response.categoryDetail())
+                .isEqualTo(PlaceCategoryDetail.HERITAGE);
+        assertThat(response.source())
+                .isEqualTo(PlaceSource.TOUR_API);
         assertThat(response.isRepresentative()).isFalse();
 
         verify(placeRepository).findById(placeId);
@@ -177,23 +238,32 @@ class PlaceServiceTest {
         // given
         Long placeId = 1L;
 
-        when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
+        when(placeRepository.findById(placeId))
+                .thenReturn(Optional.of(place));
+
         mockPlaceForDetailResponse();
-        when(tourApiPlaceClient.getPlaceDetail("1001")).thenReturn(null);
+
+        when(tourApiPlaceClient.getPlaceDetail("1001"))
+                .thenReturn(null);
 
         // when
-        PlaceDetailResponse response = placeService.getPlace(placeId);
+        PlaceDetailResponse response =
+                placeService.getPlace(placeId);
 
         // then
         assertThat(response.id()).isEqualTo(1L);
         assertThat(response.regionId()).isEqualTo(1L);
         assertThat(response.tourContentId()).isEqualTo("1001");
         assertThat(response.title()).isEqualTo("공산성");
-        assertThat(response.address()).isEqualTo("충청남도 공주시 웅진로 280");
+        assertThat(response.address())
+                .isEqualTo("충청남도 공주시 웅진로 280");
         assertThat(response.overview()).isNull();
-        assertThat(response.categoryGroup()).isEqualTo(PlaceCategoryGroup.TOURISM);
-        assertThat(response.categoryDetail()).isEqualTo(PlaceCategoryDetail.HERITAGE);
-        assertThat(response.source()).isEqualTo(PlaceSource.TOUR_API);
+        assertThat(response.categoryGroup())
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(response.categoryDetail())
+                .isEqualTo(PlaceCategoryDetail.HERITAGE);
+        assertThat(response.source())
+                .isEqualTo(PlaceSource.TOUR_API);
         assertThat(response.isRepresentative()).isFalse();
 
         verify(placeRepository).findById(placeId);
@@ -206,7 +276,8 @@ class PlaceServiceTest {
         // given
         Long placeId = 999L;
 
-        when(placeRepository.findById(placeId)).thenReturn(Optional.empty());
+        when(placeRepository.findById(placeId))
+                .thenReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> placeService.getPlace(placeId))
@@ -217,16 +288,40 @@ class PlaceServiceTest {
         verifyNoInteractions(tourApiPlaceClient);
     }
 
+    @Test
+    @DisplayName("존재하지 않는 regionId로 추가 추천 장소를 조회하면 예외가 발생한다")
+    void getExternalPlacesWithInvalidRegion() {
+        // given
+        Long regionId = 999L;
+
+        when(regionRepository.findById(regionId))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> placeService.getExternalPlaces(regionId))
+                .isInstanceOf(RegionNotFoundException.class)
+                .hasMessage("지역을 찾을 수 없습니다.");
+
+        verify(regionRepository).findById(regionId);
+        verifyNoInteractions(tourApiPlaceClient);
+    }
+
     private void mockPlaceForListResponse() {
         when(place.getId()).thenReturn(1L);
         when(place.getTourContentId()).thenReturn("1001");
         when(place.getTitle()).thenReturn("공산성");
-        when(place.getAddress()).thenReturn("충청남도 공주시 웅진로 280");
-        when(place.getLatitude()).thenReturn(new BigDecimal("36.4623000"));
-        when(place.getLongitude()).thenReturn(new BigDecimal("127.1248000"));
-        when(place.getFirstImageUrl()).thenReturn("https://example.com/image.jpg");
-        when(place.getCategoryGroup()).thenReturn(PlaceCategoryGroup.TOURISM);
-        when(place.getCategoryDetail()).thenReturn(PlaceCategoryDetail.HERITAGE);
+        when(place.getAddress())
+                .thenReturn("충청남도 공주시 웅진로 280");
+        when(place.getLatitude())
+                .thenReturn(new BigDecimal("36.4623000"));
+        when(place.getLongitude())
+                .thenReturn(new BigDecimal("127.1248000"));
+        when(place.getFirstImageUrl())
+                .thenReturn("https://example.com/image.jpg");
+        when(place.getCategoryGroup())
+                .thenReturn(PlaceCategoryGroup.TOURISM);
+        when(place.getCategoryDetail())
+                .thenReturn(PlaceCategoryDetail.HERITAGE);
         when(place.isRepresentative()).thenReturn(false);
     }
 
@@ -259,22 +354,5 @@ class PlaceServiceTest {
                 "HS010100",
                 "TourAPI 공산성 소개 문구입니다."
         );
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 regionId로 추가 추천 장소를 조회하면 예외가 발생한다")
-    void getExternalPlacesWithInvalidRegion() {
-        // given
-        Long regionId = 999L;
-
-        when(regionRepository.findById(regionId)).thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> placeService.getExternalPlaces(regionId))
-                .isInstanceOf(RegionNotFoundException.class)
-                .hasMessage("지역을 찾을 수 없습니다.");
-
-        verify(regionRepository).findById(regionId);
-        verifyNoInteractions(tourApiPlaceClient);
     }
 }


### PR DESCRIPTION
## ✨ 변경 사항

- 지역별 대표 장소 목록 조회 시 장소마다 `detailCommon2`를 순차 호출하던 구조 개선
- 대표 장소의 `tourContentId`를 기준으로 TourAPI `areaBasedList2` 조회 결과와 매칭하도록 변경
- `areaBasedList2`를 페이지 단위로 조회하고 필요한 대표 장소를 모두 찾으면 추가 페이지 조회를 중단하도록 처리
- TourAPI에서 조회된 장소는 실시간 TourAPI 정보를 반영하고, 매칭되지 않는 장소는 기존 DB 정보를 사용하도록 유지
- 목록 조회 로직 변경에 맞춰 `PlaceService` 테스트 수정

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #54 

## 🧩 API / DB 변경 사항

- 대상 API: `GET /api/places?regionId={id}`
- API 경로 및 응답 형식 변경 없음
- DB 스키마 변경 없음
- TourAPI 호출 방식 변경
  - 기존: 대표 장소별 `detailCommon2` 순차 호출
  - 변경: 지역별 `areaBasedList2` 페이지 조회 후 `contentId` 기준 대표 장소 매칭

## ✅ 테스트

- [x] 서버 실행 확인
- [x] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- 테스트 지역 기준 대표 장소 19개 중 TourAPI `contentId`를 보유한 장소는 11개였음
- 기존 구조에서는 `detailCommon2` 11회 순차 호출로 TourAPI 조회 구간 약 1,656ms, 전체 목록 조회 약 1,834ms 소요
- 개선 후 `areaBasedList2` 4페이지에서 대상 11개를 모두 매칭했으며 TourAPI 조회 구간 약 1,130ms, 전체 목록 조회 약 1,283ms 소요
- warm 상태 기준 전체 응답 시간이 약 30% 감소함
- 관광공사 OpenAPI 실시간 호출 및 실제 응답 반영 구조는 유지함
- 장소 상세 조회의 `detailCommon2` 호출은 기존대로 유지함
- Render 환경의 TourAPI 최초 연결 warm-up timeout은 본 작업과 별도로 추후 점검 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 지역별 장소 조회 시 필요한 관광 콘텐츠만 일괄 조회하도록 개선했습니다.
  * 지역 및 대표 장소 정보를 바탕으로 외부 관광 데이터를 더 효율적으로 연결합니다.
  * 외부 데이터가 없을 때도 로컬 장소 정보를 정상적으로 제공합니다.

* **버그 수정**
  * 존재하지 않는 지역이나 장소 조회 시 오류 처리를 강화했습니다.
  * 외부 API 응답이 없거나 일부만 반환되는 경우에도 결과를 안정적으로 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->