### PR TITLE
feat(place): 지역 추가 장소 조회 및 Kakao 보완

### DIFF
--- a/src/main/java/com/chaerok/backend/place/controller/PlaceController.java
+++ b/src/main/java/com/chaerok/backend/place/controller/PlaceController.java
@@ -47,7 +47,10 @@ public class PlaceController {
     }
 
     @GetMapping("/external")
-    @Operation(summary = "TourAPI 기반 지역 장소 조회", description = "regionId를 기준으로 TourAPI에서 해당 지역의 장소 목록을 실시간 조회한다. 조회 결과는 DB에 저장하지 않는다.")
+    @Operation(
+            summary = "지역 추가 장소 조회",
+            description = "TourAPI를 우선 조회하고, 음식점·카페가 부족하면 Kakao Local API로 보완한다."
+    )
     public ResponseEntity<List<PlaceListResponse>> getExternalPlaces(
             @RequestParam Long regionId
     ) {

--- a/src/main/java/com/chaerok/backend/place/dto/PlaceListResponse.java
+++ b/src/main/java/com/chaerok/backend/place/dto/PlaceListResponse.java
@@ -4,6 +4,7 @@ import com.chaerok.backend.place.entity.Place;
 import com.chaerok.backend.place.entity.PlaceCategoryDetail;
 import com.chaerok.backend.place.entity.PlaceCategoryGroup;
 import com.chaerok.backend.place.entity.PlaceSource;
+import com.chaerok.backend.place.external.KakaoPlaceItem;
 import com.chaerok.backend.place.external.TourApiPlaceItem;
 import com.chaerok.backend.place.service.PlaceCategoryMapper;
 
@@ -76,6 +77,31 @@ public record PlaceListResponse(
                 PlaceCategoryMapper.toDetail(item.lclsSystm1(), item.lclsSystm3()),
                 false,
                 PlaceSource.TOUR_API
+        );
+    }
+
+    public static PlaceListResponse fromKakao(KakaoPlaceItem item) {
+        return new PlaceListResponse(
+                null,
+                null,
+                item.id(),
+                item.placeName(),
+                item.roadAddressName() == null || item.roadAddressName().isBlank()
+                        ? item.addressName()
+                        : item.roadAddressName(),
+                toBigDecimal(item.y()),
+                toBigDecimal(item.x()),
+                null,
+                PlaceCategoryMapper.toGroupFromKakao(
+                        item.categoryGroupCode(),
+                        item.categoryName()
+                ),
+                PlaceCategoryMapper.toDetailFromKakao(
+                        item.categoryGroupCode(),
+                        item.categoryName()
+                ),
+                false,
+                PlaceSource.KAKAO_LOCAL
         );
     }
 }

--- a/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
+++ b/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
@@ -9,11 +9,7 @@ import org.springframework.web.reactive.function.client.WebClientRequestExceptio
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 @Slf4j
 @Component
@@ -36,29 +32,52 @@ public class TourApiPlaceClient {
             String lDongRegnCd,
             String lDongSignguCd
     ) {
+        List<TourApiPlaceItem> allItems = new ArrayList<>();
+
+        int pageNo = 1;
+
         try {
-            TourApiPlaceResponse response = requestPlacesByRegionPage(
-                    lDongRegnCd,
-                    lDongSignguCd,
-                    1
-            );
-
-            if (response == null) {
-                return List.of();
-            }
-
-            if (!response.isSuccess()) {
-                log.warn(
-                        "TourAPI areaBasedList2 failed. lDongRegnCd={}, lDongSignguCd={}, resultCode={}, resultMsg={}",
+            while (true) {
+                TourApiPlaceResponse response = requestPlacesByRegionPage(
                         lDongRegnCd,
                         lDongSignguCd,
-                        response.getResultCode(),
-                        response.getResultMsg()
+                        pageNo
                 );
-                return List.of();
+
+                if (response == null) {
+                    break;
+                }
+
+                if (!response.isSuccess()) {
+                    log.warn(
+                            "TourAPI areaBasedList2 failed. pageNo={}, lDongRegnCd={}, lDongSignguCd={}, resultCode={}, resultMsg={}",
+                            pageNo,
+                            lDongRegnCd,
+                            lDongSignguCd,
+                            response.getResultCode(),
+                            response.getResultMsg()
+                    );
+                    break;
+                }
+
+                List<TourApiPlaceItem> items = response.getItems();
+
+                if (items.isEmpty()) {
+                    break;
+                }
+
+                allItems.addAll(items);
+
+                int totalCount = response.getTotalCount();
+
+                if (totalCount <= pageNo * AREA_PAGE_SIZE) {
+                    break;
+                }
+
+                pageNo++;
             }
 
-            return response.getItems();
+            return allItems;
 
         } catch (WebClientResponseException e) {
             log.warn(
@@ -66,14 +85,14 @@ public class TourApiPlaceClient {
                     e.getStatusCode(),
                     e.getResponseBodyAsString()
             );
-            return List.of();
+            return allItems;
 
         } catch (WebClientRequestException e) {
             log.warn(
                     "TourAPI areaBasedList2 request error. message={}",
                     e.getMessage()
             );
-            return List.of();
+            return allItems;
 
         } catch (RuntimeException e) {
             log.error(
@@ -81,7 +100,7 @@ public class TourApiPlaceClient {
                     e.getMessage(),
                     e
             );
-            return List.of();
+            return allItems;
         }
     }
 

--- a/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
+++ b/src/main/java/com/chaerok/backend/place/external/TourApiPlaceClient.java
@@ -21,6 +21,7 @@ public class TourApiPlaceClient {
     private static final String DETAIL_COMMON_PATH = "/detailCommon2";
 
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration AREA_TOTAL_TIMEOUT = Duration.ofSeconds(10);
     private static final int AREA_PAGE_SIZE = 50;
 
     private final WebClient tourApiWebClient;
@@ -33,16 +34,32 @@ public class TourApiPlaceClient {
             String lDongSignguCd
     ) {
         List<TourApiPlaceItem> allItems = new ArrayList<>();
-
         int pageNo = 1;
+
+        long deadlineNanos =
+                System.nanoTime() + AREA_TOTAL_TIMEOUT.toNanos();
 
         try {
             while (true) {
-                TourApiPlaceResponse response = requestPlacesByRegionPage(
-                        lDongRegnCd,
-                        lDongSignguCd,
-                        pageNo
-                );
+                if (System.nanoTime() >= deadlineNanos) {
+                    log.warn(
+                            "TourAPI areaBasedList2 total timeout. " +
+                                    "pageNo={}, collectedItems={}, " +
+                                    "lDongRegnCd={}, lDongSignguCd={}",
+                            pageNo,
+                            allItems.size(),
+                            lDongRegnCd,
+                            lDongSignguCd
+                    );
+                    break;
+                }
+
+                TourApiPlaceResponse response =
+                        requestPlacesByRegionPage(
+                                lDongRegnCd,
+                                lDongSignguCd,
+                                pageNo
+                        );
 
                 if (response == null) {
                     break;
@@ -50,7 +67,9 @@ public class TourApiPlaceClient {
 
                 if (!response.isSuccess()) {
                     log.warn(
-                            "TourAPI areaBasedList2 failed. pageNo={}, lDongRegnCd={}, lDongSignguCd={}, resultCode={}, resultMsg={}",
+                            "TourAPI areaBasedList2 failed. " +
+                                    "pageNo={}, lDongRegnCd={}, lDongSignguCd={}, " +
+                                    "resultCode={}, resultMsg={}",
                             pageNo,
                             lDongRegnCd,
                             lDongSignguCd,

--- a/src/main/java/com/chaerok/backend/place/service/PlaceCategoryMapper.java
+++ b/src/main/java/com/chaerok/backend/place/service/PlaceCategoryMapper.java
@@ -6,7 +6,6 @@ import com.chaerok.backend.place.entity.PlaceCategoryGroup;
 public class PlaceCategoryMapper {
 
     private static final String CAFE_CODE = "FD05";
-    private static final String MARKET_CODE = "SH06";
 
     private static final String KAKAO_FOOD_CODE = "FD6";
     private static final String KAKAO_CAFE_CODE = "CE7";
@@ -14,7 +13,26 @@ public class PlaceCategoryMapper {
     private PlaceCategoryMapper() {
     }
 
-    public static PlaceCategoryGroup toGroup(String lclsSystm1, String lclsSystm3) {
+    public static boolean isSupportedTourApiCategory(
+            String lclsSystm1,
+            String lclsSystm3
+    ) {
+        String code = resolveCode(lclsSystm1, lclsSystm3);
+
+        if (code == null) {
+            return false;
+        }
+
+        return isTourism(code)
+                || isMarket(code)
+                || isFood(code)
+                || isCafe(code);
+    }
+
+    public static PlaceCategoryGroup toGroup(
+            String lclsSystm1,
+            String lclsSystm3
+    ) {
         String code = resolveCode(lclsSystm1, lclsSystm3);
 
         if (code == null) {
@@ -32,11 +50,18 @@ public class PlaceCategoryMapper {
         return PlaceCategoryGroup.TOURISM;
     }
 
-    public static PlaceCategoryDetail toDetail(String lclsSystm1, String lclsSystm3) {
+    public static PlaceCategoryDetail toDetail(
+            String lclsSystm1,
+            String lclsSystm3
+    ) {
         String code = resolveCode(lclsSystm1, lclsSystm3);
 
         if (code == null) {
             return null;
+        }
+
+        if (isMarket(code)) {
+            return PlaceCategoryDetail.MARKET;
         }
 
         if (isCafe(code)) {
@@ -55,10 +80,6 @@ public class PlaceCategoryMapper {
             return PlaceCategoryDetail.NATURE;
         }
 
-        if (isMarket(code)) {
-            return PlaceCategoryDetail.MARKET;
-        }
-
         if (code.startsWith("VE")) {
             return PlaceCategoryDetail.MUSEUM;
         }
@@ -66,7 +87,10 @@ public class PlaceCategoryMapper {
         return PlaceCategoryDetail.EXPERIENCE;
     }
 
-    public static PlaceCategoryGroup toGroupFromKakao(String categoryGroupCode, String categoryName) {
+    public static PlaceCategoryGroup toGroupFromKakao(
+            String categoryGroupCode,
+            String categoryName
+    ) {
         if (isKakaoCafe(categoryGroupCode, categoryName)) {
             return PlaceCategoryGroup.CAFE_DESSERT;
         }
@@ -78,7 +102,10 @@ public class PlaceCategoryMapper {
         return PlaceCategoryGroup.TOURISM;
     }
 
-    public static PlaceCategoryDetail toDetailFromKakao(String categoryGroupCode, String categoryName) {
+    public static PlaceCategoryDetail toDetailFromKakao(
+            String categoryGroupCode,
+            String categoryName
+    ) {
         String name = normalize(categoryName);
 
         if (containsAny(name, "문구", "생활용품", "인테리어", "소품", "잡화", "공방")) {
@@ -120,7 +147,10 @@ public class PlaceCategoryMapper {
         return PlaceCategoryDetail.EXPERIENCE;
     }
 
-    private static String resolveCode(String lclsSystm1, String lclsSystm3) {
+    private static String resolveCode(
+            String lclsSystm1,
+            String lclsSystm3
+    ) {
         if (lclsSystm3 != null && !lclsSystm3.isBlank()) {
             return lclsSystm3;
         }
@@ -132,26 +162,60 @@ public class PlaceCategoryMapper {
         return null;
     }
 
+    private static boolean isMarket(String code) {
+        return code.startsWith("SH06");
+    }
+
+    private static boolean isTourism(String code) {
+        return code.startsWith("EX")
+                || code.startsWith("EV")
+                || code.startsWith("HS")
+                || code.startsWith("LS")
+                || code.startsWith("NA")
+                || code.startsWith("VE");
+    }
+
     private static boolean isCafe(String code) {
         return code.startsWith(CAFE_CODE);
     }
 
     private static boolean isFood(String code) {
-        return code.startsWith("FD") && !isCafe(code);
+        return code.startsWith("FD01")
+                || code.startsWith("FD02")
+                || code.startsWith("FD03")
+                || code.startsWith("FD04");
     }
 
-    private static boolean isMarket(String code) {
-        return code.startsWith(MARKET_CODE);
-    }
-
-    private static boolean isKakaoCafe(String categoryGroupCode, String categoryName) {
+    private static boolean isKakaoCafe(
+            String categoryGroupCode,
+            String categoryName
+    ) {
         return KAKAO_CAFE_CODE.equals(categoryGroupCode)
-                || containsAny(normalize(categoryName), "카페", "커피", "디저트", "베이커리", "찻집");
+                || containsAny(
+                normalize(categoryName),
+                "카페",
+                "커피",
+                "디저트",
+                "베이커리",
+                "찻집"
+        );
     }
 
-    private static boolean isKakaoFood(String categoryGroupCode, String categoryName) {
+    private static boolean isKakaoFood(
+            String categoryGroupCode,
+            String categoryName
+    ) {
         return KAKAO_FOOD_CODE.equals(categoryGroupCode)
-                || containsAny(normalize(categoryName), "음식점", "한식", "중식", "일식", "양식", "분식", "식당");
+                || containsAny(
+                normalize(categoryName),
+                "음식점",
+                "한식",
+                "중식",
+                "일식",
+                "양식",
+                "분식",
+                "식당"
+        );
     }
 
     private static String normalize(String value) {
@@ -162,7 +226,10 @@ public class PlaceCategoryMapper {
         return value.trim();
     }
 
-    private static boolean containsAny(String value, String... keywords) {
+    private static boolean containsAny(
+            String value,
+            String... keywords
+    ) {
         for (String keyword : keywords) {
             if (value.contains(keyword)) {
                 return true;

--- a/src/main/java/com/chaerok/backend/place/service/PlaceSearchService.java
+++ b/src/main/java/com/chaerok/backend/place/service/PlaceSearchService.java
@@ -11,7 +11,6 @@ import com.chaerok.backend.region.repository.RegionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,14 +21,10 @@ public class PlaceSearchService {
 
     private static final int TOUR_API_MIN_RESULT_COUNT = 5;
 
-    private static final String GONGJU_SIGNGU_CODE = "150";
-    private static final String BUYEO_SIGNGU_CODE = "760";
-    private static final String SEOSAN_SIGNGU_CODE = "210";
-    private static final String YESAN_SIGNGU_CODE = "810";
-
     private final RegionRepository regionRepository;
     private final TourApiPlaceClient tourApiPlaceClient;
     private final KakaoLocalClient kakaoLocalClient;
+    private final RegionCenterProvider regionCenterProvider;
 
     public List<PlaceSearchResponse> searchPlaces(Long regionId, String keyword) {
         Region region = findRegion(regionId);
@@ -63,7 +58,8 @@ public class PlaceSearchService {
     }
 
     private List<PlaceSearchResponse> searchKakao(Region region, String keyword) {
-        RegionCenter center = getRegionCenter(region);
+        RegionCenterProvider.RegionCenter center =
+                regionCenterProvider.getCenter(region);
 
         List<KakaoPlaceItem> items = kakaoLocalClient.searchPlacesByKeyword(
                 keyword,
@@ -108,36 +104,5 @@ public class PlaceSearchService {
 
         return value.replaceAll("\\s+", "")
                 .toLowerCase();
-    }
-
-    private RegionCenter getRegionCenter(Region region) {
-        return switch (region.getLdongSignguCd()) {
-            case GONGJU_SIGNGU_CODE -> new RegionCenter(
-                    new BigDecimal("127.1190"),
-                    new BigDecimal("36.4465")
-            );
-            case BUYEO_SIGNGU_CODE -> new RegionCenter(
-                    new BigDecimal("126.9119"),
-                    new BigDecimal("36.2757")
-            );
-            case SEOSAN_SIGNGU_CODE -> new RegionCenter(
-                    new BigDecimal("126.4503"),
-                    new BigDecimal("36.7845")
-            );
-            case YESAN_SIGNGU_CODE -> new RegionCenter(
-                    new BigDecimal("126.8447"),
-                    new BigDecimal("36.6829")
-            );
-            default -> new RegionCenter(
-                    new BigDecimal("126.8000"),
-                    new BigDecimal("36.5000")
-            );
-        };
-    }
-
-    private record RegionCenter(
-            BigDecimal longitude,
-            BigDecimal latitude
-    ) {
     }
 }

--- a/src/main/java/com/chaerok/backend/place/service/PlaceSearchService.java
+++ b/src/main/java/com/chaerok/backend/place/service/PlaceSearchService.java
@@ -61,6 +61,10 @@ public class PlaceSearchService {
         RegionCenterProvider.RegionCenter center =
                 regionCenterProvider.getCenter(region);
 
+        if (center == null) {
+            return List.of();
+        }
+
         List<KakaoPlaceItem> items = kakaoLocalClient.searchPlacesByKeyword(
                 keyword,
                 center.longitude(),

--- a/src/main/java/com/chaerok/backend/place/service/PlaceService.java
+++ b/src/main/java/com/chaerok/backend/place/service/PlaceService.java
@@ -117,6 +117,10 @@ public class PlaceService {
         RegionCenterProvider.RegionCenter center =
                 regionCenterProvider.getCenter(region);
 
+        if (center == null) {
+            return results;
+        }
+
         if (foodShortage > 0) {
             List<KakaoPlaceItem> kakaoFoods =
                     kakaoLocalClient.searchPlacesByCategory(

--- a/src/main/java/com/chaerok/backend/place/service/PlaceService.java
+++ b/src/main/java/com/chaerok/backend/place/service/PlaceService.java
@@ -5,6 +5,9 @@ import com.chaerok.backend.global.exception.RegionNotFoundException;
 import com.chaerok.backend.place.dto.PlaceDetailResponse;
 import com.chaerok.backend.place.dto.PlaceListResponse;
 import com.chaerok.backend.place.entity.Place;
+import com.chaerok.backend.place.entity.PlaceCategoryGroup;
+import com.chaerok.backend.place.external.KakaoLocalClient;
+import com.chaerok.backend.place.external.KakaoPlaceItem;
 import com.chaerok.backend.place.external.TourApiPlaceClient;
 import com.chaerok.backend.place.external.TourApiPlaceItem;
 import com.chaerok.backend.place.repository.PlaceRepository;
@@ -14,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -24,9 +29,23 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class PlaceService {
 
+    private static final int TOURISM_LIMIT = 15;
+    private static final int FOOD_LIMIT = 15;
+    private static final int CAFE_DESSERT_LIMIT = 15;
+
+    private static final String KAKAO_FOOD_CATEGORY = "FD6";
+    private static final String KAKAO_CAFE_CATEGORY = "CE7";
+    private static final List<String> EXCLUDED_TOURISM_KEYWORDS = List.of("모텔", "호텔", "리조트", "체육센터");
+
+    private static final int KAKAO_SEARCH_RADIUS = 20_000;
+    private static final double DUPLICATE_DISTANCE_METERS = 30.0;
+    private static final double EARTH_RADIUS_METERS = 6_371_000.0;
+
     private final PlaceRepository placeRepository;
     private final RegionRepository regionRepository;
     private final TourApiPlaceClient tourApiPlaceClient;
+    private final KakaoLocalClient kakaoLocalClient;
+    private final RegionCenterProvider regionCenterProvider;
 
     public List<PlaceListResponse> getPlacesByRegion(Long regionId) {
         Region region = regionRepository.findById(regionId)
@@ -59,12 +78,281 @@ public class PlaceService {
         Region region = regionRepository.findById(regionId)
                 .orElseThrow(RegionNotFoundException::new);
 
-        return tourApiPlaceClient.getPlacesByRegion(
+        List<TourApiPlaceItem> tourApiItems =
+                tourApiPlaceClient.getPlacesByRegion(
                         region.getLdongRegnCd(),
                         region.getLdongSignguCd()
-                ).stream()
+                );
+
+        List<PlaceListResponse> results = new ArrayList<>();
+
+        addPlacesByCategory(
+                results,
+                tourApiItems,
+                PlaceCategoryGroup.TOURISM,
+                TOURISM_LIMIT
+        );
+
+        int foodCount = addPlacesByCategory(
+                results,
+                tourApiItems,
+                PlaceCategoryGroup.FOOD,
+                FOOD_LIMIT
+        );
+
+        int cafeCount = addPlacesByCategory(
+                results,
+                tourApiItems,
+                PlaceCategoryGroup.CAFE_DESSERT,
+                CAFE_DESSERT_LIMIT
+        );
+
+        int foodShortage = FOOD_LIMIT - foodCount;
+        int cafeShortage = CAFE_DESSERT_LIMIT - cafeCount;
+
+        if (foodShortage <= 0 && cafeShortage <= 0) {
+            return results;
+        }
+
+        RegionCenterProvider.RegionCenter center =
+                regionCenterProvider.getCenter(region);
+
+        if (foodShortage > 0) {
+            List<KakaoPlaceItem> kakaoFoods =
+                    kakaoLocalClient.searchPlacesByCategory(
+                            KAKAO_FOOD_CATEGORY,
+                            center.longitude(),
+                            center.latitude(),
+                            KAKAO_SEARCH_RADIUS
+                    );
+
+            addKakaoPlaces(
+                    results,
+                    kakaoFoods,
+                    region,
+                    foodShortage
+            );
+        }
+
+        if (cafeShortage > 0) {
+            List<KakaoPlaceItem> kakaoCafes =
+                    kakaoLocalClient.searchPlacesByCategory(
+                            KAKAO_CAFE_CATEGORY,
+                            center.longitude(),
+                            center.latitude(),
+                            KAKAO_SEARCH_RADIUS
+                    );
+
+            addKakaoPlaces(
+                    results,
+                    kakaoCafes,
+                    region,
+                    cafeShortage
+            );
+        }
+
+        return results;
+    }
+
+    private int addPlacesByCategory(
+            List<PlaceListResponse> results,
+            List<TourApiPlaceItem> items,
+            PlaceCategoryGroup targetCategory,
+            int limit
+    ) {
+        List<PlaceListResponse> places = items.stream()
+                .filter(item -> PlaceCategoryMapper.isSupportedTourApiCategory(
+                        item.lclsSystm1(),
+                        item.lclsSystm3()
+                ))
+                .filter(item -> PlaceCategoryMapper.toGroup(
+                        item.lclsSystm1(),
+                        item.lclsSystm3()
+                ) == targetCategory)
+                .filter(item ->
+                        targetCategory != PlaceCategoryGroup.TOURISM
+                                || !isExcludedTourismPlace(item.title())
+                )
+                .limit(limit)
                 .map(PlaceListResponse::fromTourApi)
                 .toList();
+
+        results.addAll(places);
+
+        return places.size();
+    }
+
+    private void addKakaoPlaces(
+            List<PlaceListResponse> results,
+            List<KakaoPlaceItem> kakaoItems,
+            Region region,
+            int shortage
+    ) {
+        if (shortage <= 0) {
+            return;
+        }
+
+        int addedCount = 0;
+
+        for (KakaoPlaceItem item : kakaoItems) {
+            if (addedCount >= shortage) {
+                break;
+            }
+
+            if (!isInRegion(item, region)) {
+                continue;
+            }
+
+            PlaceListResponse candidate =
+                    PlaceListResponse.fromKakao(item);
+
+            if (isDuplicatePlace(results, candidate)) {
+                continue;
+            }
+
+            results.add(candidate);
+            addedCount++;
+        }
+    }
+
+    private boolean isInRegion(
+            KakaoPlaceItem item,
+            Region region
+    ) {
+        String address = item.roadAddressName();
+
+        if (address == null || address.isBlank()) {
+            address = item.addressName();
+        }
+
+        if (address == null || address.isBlank()) {
+            return false;
+        }
+
+        return address.contains(region.getCityCountyName());
+    }
+
+    private boolean isDuplicatePlace(
+            List<PlaceListResponse> existingPlaces,
+            PlaceListResponse candidate
+    ) {
+        return existingPlaces.stream()
+                .anyMatch(existing ->
+                        isSamePlace(existing, candidate)
+                );
+    }
+
+    private boolean isSamePlace(
+            PlaceListResponse first,
+            PlaceListResponse second
+    ) {
+        String firstTitle = normalizeTitle(first.title());
+        String secondTitle = normalizeTitle(second.title());
+
+        String firstAddress = normalizeAddress(first.address());
+        String secondAddress = normalizeAddress(second.address());
+
+        if (firstTitle.isBlank() || secondTitle.isBlank()) {
+            return false;
+        }
+
+        // 이름과 주소가 동일한 경우
+        if (firstTitle.equals(secondTitle)
+                && !firstAddress.isBlank()
+                && firstAddress.equals(secondAddress)) {
+            return true;
+        }
+
+        // 이름이 서로 관련되지 않으면 다른 장소로 판단
+        if (!isSimilarTitle(firstTitle, secondTitle)) {
+            return false;
+        }
+
+        // 이름이 유사하고 좌표가 30m 이내이면 동일 장소로 판단
+        return calculateDistanceMeters(
+                first.latitude(),
+                first.longitude(),
+                second.latitude(),
+                second.longitude()
+        ) <= DUPLICATE_DISTANCE_METERS;
+    }
+
+    private boolean isSimilarTitle(
+            String first,
+            String second
+    ) {
+        return first.equals(second)
+                || first.contains(second)
+                || second.contains(first);
+    }
+
+    private String normalizeTitle(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value
+                .replaceAll("[^가-힣a-zA-Z0-9]", "")
+                .toLowerCase();
+    }
+
+    private String normalizeAddress(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value
+                .replace("충청남도", "충남")
+                .replaceAll("\\s+", "")
+                .toLowerCase();
+    }
+
+    private double calculateDistanceMeters(
+            BigDecimal latitude1,
+            BigDecimal longitude1,
+            BigDecimal latitude2,
+            BigDecimal longitude2
+    ) {
+        if (latitude1 == null
+                || longitude1 == null
+                || latitude2 == null
+                || longitude2 == null) {
+            return Double.MAX_VALUE;
+        }
+
+        double lat1 = Math.toRadians(latitude1.doubleValue());
+        double lat2 = Math.toRadians(latitude2.doubleValue());
+
+        double deltaLat = Math.toRadians(
+                latitude2.doubleValue() - latitude1.doubleValue()
+        );
+
+        double deltaLon = Math.toRadians(
+                longitude2.doubleValue() - longitude1.doubleValue()
+        );
+
+        double a =
+                Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2)
+                        + Math.cos(lat1)
+                        * Math.cos(lat2)
+                        * Math.sin(deltaLon / 2)
+                        * Math.sin(deltaLon / 2);
+
+        double c = 2 * Math.atan2(
+                Math.sqrt(a),
+                Math.sqrt(1 - a)
+        );
+
+        return EARTH_RADIUS_METERS * c;
+    }
+
+    private boolean isExcludedTourismPlace(String title) {
+        if (title == null || title.isBlank()) {
+            return false;
+        }
+
+        return EXCLUDED_TOURISM_KEYWORDS.stream()
+                .anyMatch(title::contains);
     }
 
     private PlaceListResponse toPlaceListResponse(
@@ -83,7 +371,9 @@ public class PlaceService {
                 .orElseThrow(PlaceNotFoundException::new);
 
         TourApiPlaceItem tourApiItem =
-                tourApiPlaceClient.getPlaceDetail(place.getTourContentId());
+                tourApiPlaceClient.getPlaceDetail(
+                        place.getTourContentId()
+                );
 
         if (tourApiItem == null) {
             return PlaceDetailResponse.from(place);

--- a/src/main/java/com/chaerok/backend/place/service/RegionCenterProvider.java
+++ b/src/main/java/com/chaerok/backend/place/service/RegionCenterProvider.java
@@ -31,10 +31,7 @@ public class RegionCenterProvider {
                     new BigDecimal("126.8447"),
                     new BigDecimal("36.6829")
             );
-            default -> new RegionCenter(
-                    new BigDecimal("126.8000"),
-                    new BigDecimal("36.5000")
-            );
+            default -> null;
         };
     }
 

--- a/src/main/java/com/chaerok/backend/place/service/RegionCenterProvider.java
+++ b/src/main/java/com/chaerok/backend/place/service/RegionCenterProvider.java
@@ -1,0 +1,46 @@
+package com.chaerok.backend.place.service;
+
+import com.chaerok.backend.region.entity.Region;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+@Component
+public class RegionCenterProvider {
+
+    private static final String GONGJU_SIGNGU_CODE = "150";
+    private static final String BUYEO_SIGNGU_CODE = "760";
+    private static final String SEOSAN_SIGNGU_CODE = "210";
+    private static final String YESAN_SIGNGU_CODE = "810";
+
+    public RegionCenter getCenter(Region region) {
+        return switch (region.getLdongSignguCd()) {
+            case GONGJU_SIGNGU_CODE -> new RegionCenter(
+                    new BigDecimal("127.1190"),
+                    new BigDecimal("36.4465")
+            );
+            case BUYEO_SIGNGU_CODE -> new RegionCenter(
+                    new BigDecimal("126.9119"),
+                    new BigDecimal("36.2757")
+            );
+            case SEOSAN_SIGNGU_CODE -> new RegionCenter(
+                    new BigDecimal("126.4503"),
+                    new BigDecimal("36.7845")
+            );
+            case YESAN_SIGNGU_CODE -> new RegionCenter(
+                    new BigDecimal("126.8447"),
+                    new BigDecimal("36.6829")
+            );
+            default -> new RegionCenter(
+                    new BigDecimal("126.8000"),
+                    new BigDecimal("36.5000")
+            );
+        };
+    }
+
+    public record RegionCenter(
+            BigDecimal longitude,
+            BigDecimal latitude
+    ) {
+    }
+}

--- a/src/test/java/com/chaerok/backend/place/service/PlaceCategoryMapperTest.java
+++ b/src/test/java/com/chaerok/backend/place/service/PlaceCategoryMapperTest.java
@@ -12,128 +12,255 @@ class PlaceCategoryMapperTest {
     @Test
     @DisplayName("관광지 분류 코드는 TOURISM으로 매핑된다")
     void tourismCodesToGroup() {
-        assertThat(PlaceCategoryMapper.toGroup("EX", "EX010100")).isEqualTo(PlaceCategoryGroup.TOURISM);
-        assertThat(PlaceCategoryMapper.toGroup("EV", "EV010100")).isEqualTo(PlaceCategoryGroup.TOURISM);
-        assertThat(PlaceCategoryMapper.toGroup("HS", "HS010100")).isEqualTo(PlaceCategoryGroup.TOURISM);
-        assertThat(PlaceCategoryMapper.toGroup("LS", "LS010100")).isEqualTo(PlaceCategoryGroup.TOURISM);
-        assertThat(PlaceCategoryMapper.toGroup("NA", "NA010100")).isEqualTo(PlaceCategoryGroup.TOURISM);
-        assertThat(PlaceCategoryMapper.toGroup("VE", "VE010100")).isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(PlaceCategoryMapper.toGroup("EX", "EX010100"))
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(PlaceCategoryMapper.toGroup("EV", "EV010100"))
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(PlaceCategoryMapper.toGroup("HS", "HS010100"))
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(PlaceCategoryMapper.toGroup("LS", "LS010100"))
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(PlaceCategoryMapper.toGroup("NA", "NA010100"))
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(PlaceCategoryMapper.toGroup("VE", "VE010100"))
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
     }
 
     @Test
     @DisplayName("음식점 분류 코드는 FOOD로 매핑된다")
     void foodCodesToGroup() {
-        assertThat(PlaceCategoryMapper.toGroup("FD", "FD010100")).isEqualTo(PlaceCategoryGroup.FOOD);
-        assertThat(PlaceCategoryMapper.toGroup("FD", "FD020100")).isEqualTo(PlaceCategoryGroup.FOOD);
-        assertThat(PlaceCategoryMapper.toGroup("FD", "FD030100")).isEqualTo(PlaceCategoryGroup.FOOD);
-        assertThat(PlaceCategoryMapper.toGroup("FD", "FD040100")).isEqualTo(PlaceCategoryGroup.FOOD);
+        assertThat(PlaceCategoryMapper.toGroup("FD", "FD010100"))
+                .isEqualTo(PlaceCategoryGroup.FOOD);
+        assertThat(PlaceCategoryMapper.toGroup("FD", "FD020100"))
+                .isEqualTo(PlaceCategoryGroup.FOOD);
+        assertThat(PlaceCategoryMapper.toGroup("FD", "FD030100"))
+                .isEqualTo(PlaceCategoryGroup.FOOD);
+        assertThat(PlaceCategoryMapper.toGroup("FD", "FD040100"))
+                .isEqualTo(PlaceCategoryGroup.FOOD);
     }
 
     @Test
     @DisplayName("카페/찻집 분류 코드는 CAFE_DESSERT로 매핑된다")
     void cafeCodeToGroup() {
-        assertThat(PlaceCategoryMapper.toGroup("FD", "FD050100")).isEqualTo(PlaceCategoryGroup.CAFE_DESSERT);
+        assertThat(PlaceCategoryMapper.toGroup("FD", "FD050100"))
+                .isEqualTo(PlaceCategoryGroup.CAFE_DESSERT);
     }
 
     @Test
     @DisplayName("시장 분류 코드는 TOURISM으로 매핑된다")
     void marketCodeToGroup() {
-        assertThat(PlaceCategoryMapper.toGroup("SH", "SH060100")).isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(PlaceCategoryMapper.toGroup("SH", "SH060100"))
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
     }
 
     @Test
     @DisplayName("관광지 분류 코드는 세부 유형으로 매핑된다")
     void tourismCodesToDetail() {
-        assertThat(PlaceCategoryMapper.toDetail("EX", "EX010100")).isEqualTo(PlaceCategoryDetail.EXPERIENCE);
-        assertThat(PlaceCategoryMapper.toDetail("EV", "EV010100")).isEqualTo(PlaceCategoryDetail.EXPERIENCE);
-        assertThat(PlaceCategoryMapper.toDetail("HS", "HS010100")).isEqualTo(PlaceCategoryDetail.HERITAGE);
-        assertThat(PlaceCategoryMapper.toDetail("LS", "LS010100")).isEqualTo(PlaceCategoryDetail.EXPERIENCE);
-        assertThat(PlaceCategoryMapper.toDetail("NA", "NA010100")).isEqualTo(PlaceCategoryDetail.NATURE);
-        assertThat(PlaceCategoryMapper.toDetail("VE", "VE010100")).isEqualTo(PlaceCategoryDetail.MUSEUM);
+        assertThat(PlaceCategoryMapper.toDetail("EX", "EX010100"))
+                .isEqualTo(PlaceCategoryDetail.EXPERIENCE);
+        assertThat(PlaceCategoryMapper.toDetail("EV", "EV010100"))
+                .isEqualTo(PlaceCategoryDetail.EXPERIENCE);
+        assertThat(PlaceCategoryMapper.toDetail("HS", "HS010100"))
+                .isEqualTo(PlaceCategoryDetail.HERITAGE);
+        assertThat(PlaceCategoryMapper.toDetail("LS", "LS010100"))
+                .isEqualTo(PlaceCategoryDetail.EXPERIENCE);
+        assertThat(PlaceCategoryMapper.toDetail("NA", "NA010100"))
+                .isEqualTo(PlaceCategoryDetail.NATURE);
+        assertThat(PlaceCategoryMapper.toDetail("VE", "VE010100"))
+                .isEqualTo(PlaceCategoryDetail.MUSEUM);
     }
 
     @Test
     @DisplayName("음식점 분류 코드는 RESTAURANT로 매핑된다")
     void foodCodesToDetail() {
-        assertThat(PlaceCategoryMapper.toDetail("FD", "FD010100")).isEqualTo(PlaceCategoryDetail.RESTAURANT);
-        assertThat(PlaceCategoryMapper.toDetail("FD", "FD020100")).isEqualTo(PlaceCategoryDetail.RESTAURANT);
-        assertThat(PlaceCategoryMapper.toDetail("FD", "FD030100")).isEqualTo(PlaceCategoryDetail.RESTAURANT);
-        assertThat(PlaceCategoryMapper.toDetail("FD", "FD040100")).isEqualTo(PlaceCategoryDetail.RESTAURANT);
+        assertThat(PlaceCategoryMapper.toDetail("FD", "FD010100"))
+                .isEqualTo(PlaceCategoryDetail.RESTAURANT);
+        assertThat(PlaceCategoryMapper.toDetail("FD", "FD020100"))
+                .isEqualTo(PlaceCategoryDetail.RESTAURANT);
+        assertThat(PlaceCategoryMapper.toDetail("FD", "FD030100"))
+                .isEqualTo(PlaceCategoryDetail.RESTAURANT);
+        assertThat(PlaceCategoryMapper.toDetail("FD", "FD040100"))
+                .isEqualTo(PlaceCategoryDetail.RESTAURANT);
     }
 
     @Test
     @DisplayName("카페/찻집 분류 코드는 CAFE로 매핑된다")
     void cafeCodeToDetail() {
-        assertThat(PlaceCategoryMapper.toDetail("FD", "FD050100")).isEqualTo(PlaceCategoryDetail.CAFE);
+        assertThat(PlaceCategoryMapper.toDetail("FD", "FD050100"))
+                .isEqualTo(PlaceCategoryDetail.CAFE);
     }
 
     @Test
     @DisplayName("시장 분류 코드는 MARKET으로 매핑된다")
     void marketCodeToDetail() {
-        assertThat(PlaceCategoryMapper.toDetail("SH", "SH060100")).isEqualTo(PlaceCategoryDetail.MARKET);
+        assertThat(PlaceCategoryMapper.toDetail("SH", "SH060100"))
+                .isEqualTo(PlaceCategoryDetail.MARKET);
+    }
+
+    @Test
+    @DisplayName("채록에서 사용하는 TourAPI 분류 코드는 지원 대상으로 판단한다")
+    void supportedTourApiCategories() {
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("EX", "EX010100"))
+                .isTrue();
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("EV", "EV010100"))
+                .isTrue();
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("HS", "HS010100"))
+                .isTrue();
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("LS", "LS010100"))
+                .isTrue();
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("NA", "NA010100"))
+                .isTrue();
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("VE", "VE010100"))
+                .isTrue();
+
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("SH", "SH060100"))
+                .isTrue();
+
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("FD", "FD010100"))
+                .isTrue();
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("FD", "FD020100"))
+                .isTrue();
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("FD", "FD030100"))
+                .isTrue();
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("FD", "FD040100"))
+                .isTrue();
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("FD", "FD050100"))
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("채록에서 사용하지 않는 TourAPI 분류 코드는 지원 대상에서 제외한다")
+    void unsupportedTourApiCategories() {
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("SH", "SH010100"))
+                .isFalse();
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("AC", "AC010100"))
+                .isFalse();
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory("FD", "FD060100"))
+                .isFalse();
+        assertThat(PlaceCategoryMapper.isSupportedTourApiCategory(null, null))
+                .isFalse();
     }
 
     @Test
     @DisplayName("lclsSystm3가 없으면 lclsSystm1 기준으로 매핑된다")
     void fallbackToLclsSystm1() {
-        assertThat(PlaceCategoryMapper.toGroup("HS", null)).isEqualTo(PlaceCategoryGroup.TOURISM);
-        assertThat(PlaceCategoryMapper.toDetail("HS", null)).isEqualTo(PlaceCategoryDetail.HERITAGE);
+        assertThat(PlaceCategoryMapper.toGroup("HS", null))
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(PlaceCategoryMapper.toDetail("HS", null))
+                .isEqualTo(PlaceCategoryDetail.HERITAGE);
     }
 
     @Test
     @DisplayName("분류 코드가 없으면 TOURISM과 null 세부 유형을 반환한다")
     void nullCode() {
-        assertThat(PlaceCategoryMapper.toGroup(null, null)).isEqualTo(PlaceCategoryGroup.TOURISM);
-        assertThat(PlaceCategoryMapper.toDetail(null, null)).isNull();
+        assertThat(PlaceCategoryMapper.toGroup(null, null))
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(PlaceCategoryMapper.toDetail(null, null))
+                .isNull();
     }
 
     @Test
     @DisplayName("Kakao 카페 카테고리를 CAFE_DESSERT/CAFE로 매핑한다")
     void mapKakaoCafe() {
-        PlaceCategoryGroup group = PlaceCategoryMapper.toGroupFromKakao("CE7", "음식점 > 카페");
-        PlaceCategoryDetail detail = PlaceCategoryMapper.toDetailFromKakao("CE7", "음식점 > 카페");
+        PlaceCategoryGroup group =
+                PlaceCategoryMapper.toGroupFromKakao(
+                        "CE7",
+                        "음식점 > 카페"
+                );
 
-        assertThat(group).isEqualTo(PlaceCategoryGroup.CAFE_DESSERT);
-        assertThat(detail).isEqualTo(PlaceCategoryDetail.CAFE);
+        PlaceCategoryDetail detail =
+                PlaceCategoryMapper.toDetailFromKakao(
+                        "CE7",
+                        "음식점 > 카페"
+                );
+
+        assertThat(group)
+                .isEqualTo(PlaceCategoryGroup.CAFE_DESSERT);
+        assertThat(detail)
+                .isEqualTo(PlaceCategoryDetail.CAFE);
     }
 
     @Test
     @DisplayName("Kakao 음식점 카테고리를 FOOD/RESTAURANT로 매핑한다")
     void mapKakaoRestaurant() {
-        PlaceCategoryGroup group = PlaceCategoryMapper.toGroupFromKakao("FD6", "음식점 > 한식");
-        PlaceCategoryDetail detail = PlaceCategoryMapper.toDetailFromKakao("FD6", "음식점 > 한식");
+        PlaceCategoryGroup group =
+                PlaceCategoryMapper.toGroupFromKakao(
+                        "FD6",
+                        "음식점 > 한식"
+                );
 
-        assertThat(group).isEqualTo(PlaceCategoryGroup.FOOD);
-        assertThat(detail).isEqualTo(PlaceCategoryDetail.LOCAL_FOOD);
+        PlaceCategoryDetail detail =
+                PlaceCategoryMapper.toDetailFromKakao(
+                        "FD6",
+                        "음식점 > 한식"
+                );
+
+        assertThat(group)
+                .isEqualTo(PlaceCategoryGroup.FOOD);
+        assertThat(detail)
+                .isEqualTo(PlaceCategoryDetail.LOCAL_FOOD);
     }
 
     @Test
     @DisplayName("Kakao 베이커리 카테고리를 CAFE_DESSERT/BAKERY로 매핑한다")
     void mapKakaoBakery() {
-        PlaceCategoryGroup group = PlaceCategoryMapper.toGroupFromKakao("CE7", "음식점 > 카페 > 베이커리");
-        PlaceCategoryDetail detail = PlaceCategoryMapper.toDetailFromKakao("CE7", "음식점 > 카페 > 베이커리");
+        PlaceCategoryGroup group =
+                PlaceCategoryMapper.toGroupFromKakao(
+                        "CE7",
+                        "음식점 > 카페 > 베이커리"
+                );
 
-        assertThat(group).isEqualTo(PlaceCategoryGroup.CAFE_DESSERT);
-        assertThat(detail).isEqualTo(PlaceCategoryDetail.BAKERY);
+        PlaceCategoryDetail detail =
+                PlaceCategoryMapper.toDetailFromKakao(
+                        "CE7",
+                        "음식점 > 카페 > 베이커리"
+                );
+
+        assertThat(group)
+                .isEqualTo(PlaceCategoryGroup.CAFE_DESSERT);
+        assertThat(detail)
+                .isEqualTo(PlaceCategoryDetail.BAKERY);
     }
 
     @Test
     @DisplayName("Kakao 분식 카테고리를 FOOD/SNACK_MEAL로 매핑한다")
     void mapKakaoSnackMeal() {
-        PlaceCategoryGroup group = PlaceCategoryMapper.toGroupFromKakao("FD6", "음식점 > 분식");
-        PlaceCategoryDetail detail = PlaceCategoryMapper.toDetailFromKakao("FD6", "음식점 > 분식");
+        PlaceCategoryGroup group =
+                PlaceCategoryMapper.toGroupFromKakao(
+                        "FD6",
+                        "음식점 > 분식"
+                );
 
-        assertThat(group).isEqualTo(PlaceCategoryGroup.FOOD);
-        assertThat(detail).isEqualTo(PlaceCategoryDetail.SNACK_MEAL);
+        PlaceCategoryDetail detail =
+                PlaceCategoryMapper.toDetailFromKakao(
+                        "FD6",
+                        "음식점 > 분식"
+                );
+
+        assertThat(group)
+                .isEqualTo(PlaceCategoryGroup.FOOD);
+        assertThat(detail)
+                .isEqualTo(PlaceCategoryDetail.SNACK_MEAL);
     }
 
     @Test
     @DisplayName("Kakao 소품 관련 카테고리를 TOURISM/SOUVENIR_SHOP으로 매핑한다")
     void mapKakaoSouvenirShop() {
-        PlaceCategoryGroup group = PlaceCategoryMapper.toGroupFromKakao("", "쇼핑 > 생활용품 > 소품");
-        PlaceCategoryDetail detail = PlaceCategoryMapper.toDetailFromKakao("", "쇼핑 > 생활용품 > 소품");
+        PlaceCategoryGroup group =
+                PlaceCategoryMapper.toGroupFromKakao(
+                        "",
+                        "쇼핑 > 생활용품 > 소품"
+                );
 
-        assertThat(group).isEqualTo(PlaceCategoryGroup.TOURISM);
-        assertThat(detail).isEqualTo(PlaceCategoryDetail.SOUVENIR_SHOP);
+        PlaceCategoryDetail detail =
+                PlaceCategoryMapper.toDetailFromKakao(
+                        "",
+                        "쇼핑 > 생활용품 > 소품"
+                );
+
+        assertThat(group)
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(detail)
+                .isEqualTo(PlaceCategoryDetail.SOUVENIR_SHOP);
     }
 }

--- a/src/test/java/com/chaerok/backend/place/service/PlaceSearchServiceTest.java
+++ b/src/test/java/com/chaerok/backend/place/service/PlaceSearchServiceTest.java
@@ -1,0 +1,218 @@
+package com.chaerok.backend.place.service;
+
+import com.chaerok.backend.place.dto.PlaceSearchResponse;
+import com.chaerok.backend.place.external.KakaoLocalClient;
+import com.chaerok.backend.place.external.KakaoPlaceItem;
+import com.chaerok.backend.place.external.TourApiPlaceClient;
+import com.chaerok.backend.place.external.TourApiPlaceItem;
+import com.chaerok.backend.region.entity.Region;
+import com.chaerok.backend.region.repository.RegionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PlaceSearchServiceTest {
+
+    @Mock
+    private RegionRepository regionRepository;
+
+    @Mock
+    private TourApiPlaceClient tourApiPlaceClient;
+
+    @Mock
+    private KakaoLocalClient kakaoLocalClient;
+
+    @Mock
+    private RegionCenterProvider regionCenterProvider;
+
+    @Mock
+    private Region region;
+
+    private PlaceSearchService placeSearchService;
+
+    @BeforeEach
+    void setUp() {
+        placeSearchService = new PlaceSearchService(
+                regionRepository,
+                tourApiPlaceClient,
+                kakaoLocalClient,
+                regionCenterProvider
+        );
+    }
+
+    @Test
+    @DisplayName("TourAPI 검색 결과가 5개 이상이면 Kakao 검색을 호출하지 않는다")
+    void searchPlacesReturnsTourApiOnlyWhenEnoughResults() {
+        // given
+        Long regionId = 1L;
+        String keyword = "공주";
+
+        when(regionRepository.findById(regionId))
+                .thenReturn(Optional.of(region));
+        when(region.getLdongRegnCd()).thenReturn("44");
+        when(region.getLdongSignguCd()).thenReturn("150");
+
+        List<TourApiPlaceItem> items = List.of(
+                createTourApiItem("1001", "공산성"),
+                createTourApiItem("1002", "무령왕릉"),
+                createTourApiItem("1003", "마곡사"),
+                createTourApiItem("1004", "제민천"),
+                createTourApiItem("1005", "석장리박물관")
+        );
+
+        when(tourApiPlaceClient.searchPlacesByKeyword(
+                keyword,
+                "44",
+                "150"
+        )).thenReturn(items);
+
+        // when
+        List<PlaceSearchResponse> responses =
+                placeSearchService.searchPlaces(regionId, keyword);
+
+        // then
+        assertThat(responses).hasSize(5);
+
+        assertThat(responses)
+                .extracting(PlaceSearchResponse::title)
+                .containsExactly(
+                        "공산성",
+                        "무령왕릉",
+                        "마곡사",
+                        "제민천",
+                        "석장리박물관"
+                );
+
+        verifyNoInteractions(kakaoLocalClient);
+        verifyNoInteractions(regionCenterProvider);
+    }
+
+    @Test
+    @DisplayName("TourAPI 검색 결과가 부족하면 Kakao 검색 결과로 보완한다")
+    void searchPlacesSupplementsWithKakao() {
+        // given
+        Long regionId = 1L;
+        String keyword = "카페";
+
+        when(regionRepository.findById(regionId))
+                .thenReturn(Optional.of(region));
+        when(region.getLdongRegnCd()).thenReturn("44");
+        when(region.getLdongSignguCd()).thenReturn("150");
+
+        when(tourApiPlaceClient.searchPlacesByKeyword(
+                keyword,
+                "44",
+                "150"
+        )).thenReturn(List.of(
+                createTourApiItem("1001", "공주 카페")
+        ));
+
+        RegionCenterProvider.RegionCenter center =
+                new RegionCenterProvider.RegionCenter(
+                        new BigDecimal("127.1190"),
+                        new BigDecimal("36.4465")
+                );
+
+        when(regionCenterProvider.getCenter(region))
+                .thenReturn(center);
+
+        KakaoPlaceItem kakaoItem = new KakaoPlaceItem(
+                "kakao-1",
+                "제민천 카페",
+                "음식점 > 카페",
+                "CE7",
+                "카페",
+                "충청남도 공주시 중동",
+                "충청남도 공주시 웅진로 10",
+                "127.1200",
+                "36.4500",
+                "https://place.map.kakao.com/1"
+        );
+
+        when(kakaoLocalClient.searchPlacesByKeyword(
+                keyword,
+                center.longitude(),
+                center.latitude()
+        )).thenReturn(List.of(kakaoItem));
+
+        // when
+        List<PlaceSearchResponse> responses =
+                placeSearchService.searchPlaces(regionId, keyword);
+
+        // then
+        assertThat(responses).hasSize(2);
+
+        assertThat(responses)
+                .extracting(PlaceSearchResponse::title)
+                .containsExactly(
+                        "공주 카페",
+                        "제민천 카페"
+                );
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 지역이면 Kakao 검색 없이 TourAPI 검색 결과만 반환한다")
+    void searchPlacesSkipsKakaoWhenRegionCenterIsMissing() {
+        // given
+        Long regionId = 1L;
+        String keyword = "공산성";
+
+        when(regionRepository.findById(regionId))
+                .thenReturn(Optional.of(region));
+        when(region.getLdongRegnCd()).thenReturn("44");
+        when(region.getLdongSignguCd()).thenReturn("999");
+
+        when(tourApiPlaceClient.searchPlacesByKeyword(
+                keyword,
+                "44",
+                "999"
+        )).thenReturn(List.of(
+                createTourApiItem("1001", "공산성")
+        ));
+
+        when(regionCenterProvider.getCenter(region))
+                .thenReturn(null);
+
+        // when
+        List<PlaceSearchResponse> responses =
+                placeSearchService.searchPlaces(regionId, keyword);
+
+        // then
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).title()).isEqualTo("공산성");
+
+        verifyNoInteractions(kakaoLocalClient);
+    }
+
+    private TourApiPlaceItem createTourApiItem(
+            String contentId,
+            String title
+    ) {
+        return new TourApiPlaceItem(
+                contentId,
+                title,
+                "충청남도 공주시",
+                "36.4623",
+                "127.1248",
+                null,
+                "44",
+                "150",
+                "HS",
+                "HS01",
+                "HS010100",
+                null
+        );
+    }
+}

--- a/src/test/java/com/chaerok/backend/place/service/PlaceServiceTest.java
+++ b/src/test/java/com/chaerok/backend/place/service/PlaceServiceTest.java
@@ -8,6 +8,8 @@ import com.chaerok.backend.place.entity.Place;
 import com.chaerok.backend.place.entity.PlaceCategoryDetail;
 import com.chaerok.backend.place.entity.PlaceCategoryGroup;
 import com.chaerok.backend.place.entity.PlaceSource;
+import com.chaerok.backend.place.external.KakaoLocalClient;
+import com.chaerok.backend.place.external.KakaoPlaceItem;
 import com.chaerok.backend.place.external.TourApiPlaceClient;
 import com.chaerok.backend.place.external.TourApiPlaceItem;
 import com.chaerok.backend.place.repository.PlaceRepository;
@@ -45,6 +47,12 @@ class PlaceServiceTest {
     private TourApiPlaceClient tourApiPlaceClient;
 
     @Mock
+    private KakaoLocalClient kakaoLocalClient;
+
+    @Mock
+    private RegionCenterProvider regionCenterProvider;
+
+    @Mock
     private Region region;
 
     @Mock
@@ -57,7 +65,9 @@ class PlaceServiceTest {
         placeService = new PlaceService(
                 placeRepository,
                 regionRepository,
-                tourApiPlaceClient
+                tourApiPlaceClient,
+                kakaoLocalClient,
+                regionCenterProvider
         );
     }
 
@@ -67,7 +77,8 @@ class PlaceServiceTest {
         // given
         Long regionId = 1L;
 
-        when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
+        when(regionRepository.findById(regionId))
+                .thenReturn(Optional.of(region));
         when(region.getLdongRegnCd()).thenReturn("44");
         when(region.getLdongSignguCd()).thenReturn("150");
 
@@ -126,7 +137,8 @@ class PlaceServiceTest {
         // given
         Long regionId = 1L;
 
-        when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
+        when(regionRepository.findById(regionId))
+                .thenReturn(Optional.of(region));
         when(region.getLdongRegnCd()).thenReturn("44");
         when(region.getLdongSignguCd()).thenReturn("150");
 
@@ -187,6 +199,336 @@ class PlaceServiceTest {
         verify(regionRepository).findById(regionId);
         verifyNoInteractions(placeRepository);
         verifyNoInteractions(tourApiPlaceClient);
+        verifyNoInteractions(kakaoLocalClient);
+        verifyNoInteractions(regionCenterProvider);
+    }
+
+    @Test
+    @DisplayName("추가 장소 조회 시 TourAPI 결과에서 카테고리별 장소를 반환한다")
+    void getExternalPlaces() {
+        // given
+        Long regionId = 1L;
+
+        when(regionRepository.findById(regionId))
+                .thenReturn(Optional.of(region));
+        when(region.getLdongRegnCd()).thenReturn("44");
+        when(region.getLdongSignguCd()).thenReturn("150");
+
+        List<TourApiPlaceItem> items = List.of(
+                createTourismItem(),
+                createFoodItem(),
+                createCafeItem()
+        );
+
+        when(tourApiPlaceClient.getPlacesByRegion("44", "150"))
+                .thenReturn(items);
+
+        RegionCenterProvider.RegionCenter center =
+                new RegionCenterProvider.RegionCenter(
+                        new BigDecimal("127.1190"),
+                        new BigDecimal("36.4465")
+                );
+
+        when(regionCenterProvider.getCenter(region))
+                .thenReturn(center);
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "FD6",
+                center.longitude(),
+                center.latitude(),
+                20000
+        )).thenReturn(List.of());
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "CE7",
+                center.longitude(),
+                center.latitude(),
+                20000
+        )).thenReturn(List.of());
+
+        // when
+        List<PlaceListResponse> responses =
+                placeService.getExternalPlaces(regionId);
+
+        // then
+        assertThat(responses).hasSize(3);
+
+        assertThat(responses)
+                .extracting(PlaceListResponse::categoryGroup)
+                .containsExactly(
+                        PlaceCategoryGroup.TOURISM,
+                        PlaceCategoryGroup.FOOD,
+                        PlaceCategoryGroup.CAFE_DESSERT
+                );
+
+        verify(tourApiPlaceClient)
+                .getPlacesByRegion("44", "150");
+    }
+
+    @Test
+    @DisplayName("TourAPI 음식점과 카페가 부족하면 Kakao Local 결과로 보완한다")
+    void getExternalPlacesWithKakaoFallback() {
+        // given
+        Long regionId = 1L;
+
+        when(regionRepository.findById(regionId))
+                .thenReturn(Optional.of(region));
+        when(region.getLdongRegnCd()).thenReturn("44");
+        when(region.getLdongSignguCd()).thenReturn("150");
+        when(region.getCityCountyName()).thenReturn("공주시");
+
+        when(tourApiPlaceClient.getPlacesByRegion("44", "150"))
+                .thenReturn(List.of(createTourismItem()));
+
+        RegionCenterProvider.RegionCenter center =
+                new RegionCenterProvider.RegionCenter(
+                        new BigDecimal("127.1190"),
+                        new BigDecimal("36.4465")
+                );
+
+        when(regionCenterProvider.getCenter(region))
+                .thenReturn(center);
+
+        KakaoPlaceItem food = new KakaoPlaceItem(
+                "kakao-food-1",
+                "공주 맛집",
+                "음식점 > 한식",
+                "FD6",
+                "음식점",
+                "충청남도 공주시 중동 1",
+                "충청남도 공주시 웅진로 1",
+                "127.1200",
+                "36.4500",
+                "https://place.map.kakao.com/1"
+        );
+
+        KakaoPlaceItem cafe = new KakaoPlaceItem(
+                "kakao-cafe-1",
+                "공주 카페",
+                "음식점 > 카페",
+                "CE7",
+                "카페",
+                "충청남도 공주시 중동 2",
+                "충청남도 공주시 웅진로 2",
+                "127.1210",
+                "36.4510",
+                "https://place.map.kakao.com/2"
+        );
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "FD6",
+                center.longitude(),
+                center.latitude(),
+                20000
+        )).thenReturn(List.of(food));
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "CE7",
+                center.longitude(),
+                center.latitude(),
+                20000
+        )).thenReturn(List.of(cafe));
+
+        // when
+        List<PlaceListResponse> responses =
+                placeService.getExternalPlaces(regionId);
+
+        // then
+        assertThat(responses).hasSize(3);
+
+        assertThat(responses)
+                .extracting(PlaceListResponse::source)
+                .contains(
+                        PlaceSource.TOUR_API,
+                        PlaceSource.KAKAO_LOCAL
+                );
+
+        assertThat(responses)
+                .extracting(PlaceListResponse::title)
+                .contains(
+                        "공산성",
+                        "공주 맛집",
+                        "공주 카페"
+                );
+    }
+
+    @Test
+    @DisplayName("다른 시군의 Kakao 장소는 추가 장소 결과에서 제외한다")
+    void getExternalPlacesExcludesKakaoPlacesOutsideRegion() {
+        // given
+        Long regionId = 1L;
+
+        when(regionRepository.findById(regionId))
+                .thenReturn(Optional.of(region));
+        when(region.getLdongRegnCd()).thenReturn("44");
+        when(region.getLdongSignguCd()).thenReturn("150");
+        when(region.getCityCountyName()).thenReturn("공주시");
+
+        when(tourApiPlaceClient.getPlacesByRegion("44", "150"))
+                .thenReturn(List.of());
+
+        RegionCenterProvider.RegionCenter center =
+                new RegionCenterProvider.RegionCenter(
+                        new BigDecimal("127.1190"),
+                        new BigDecimal("36.4465")
+                );
+
+        when(regionCenterProvider.getCenter(region))
+                .thenReturn(center);
+
+        KakaoPlaceItem outsideFood = new KakaoPlaceItem(
+                "kakao-food-outside",
+                "논산 식당",
+                "음식점 > 한식",
+                "FD6",
+                "음식점",
+                "충청남도 논산시 취암동",
+                "충청남도 논산시 시민로 1",
+                "127.0000",
+                "36.2000",
+                "https://place.map.kakao.com/3"
+        );
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "FD6",
+                center.longitude(),
+                center.latitude(),
+                20000
+        )).thenReturn(List.of(outsideFood));
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "CE7",
+                center.longitude(),
+                center.latitude(),
+                20000
+        )).thenReturn(List.of());
+
+        // when
+        List<PlaceListResponse> responses =
+                placeService.getExternalPlaces(regionId);
+
+        // then
+        assertThat(responses).isEmpty();
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 TourAPI 분류 장소는 추가 장소 결과에서 제외한다")
+    void getExternalPlacesExcludesUnsupportedTourApiCategory() {
+        // given
+        Long regionId = 1L;
+
+        when(regionRepository.findById(regionId))
+                .thenReturn(Optional.of(region));
+        when(region.getLdongRegnCd()).thenReturn("44");
+        when(region.getLdongSignguCd()).thenReturn("150");
+
+        TourApiPlaceItem unsupportedItem = new TourApiPlaceItem(
+                "3001",
+                "일반 쇼핑 매장",
+                "충청남도 공주시",
+                "36.4500000",
+                "127.1200000",
+                null,
+                "44",
+                "150",
+                "SH",
+                "SH01",
+                "SH010100",
+                null
+        );
+
+        when(tourApiPlaceClient.getPlacesByRegion("44", "150"))
+                .thenReturn(List.of(unsupportedItem));
+
+        RegionCenterProvider.RegionCenter center =
+                new RegionCenterProvider.RegionCenter(
+                        new BigDecimal("127.1190"),
+                        new BigDecimal("36.4465")
+                );
+
+        when(regionCenterProvider.getCenter(region))
+                .thenReturn(center);
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "FD6",
+                center.longitude(),
+                center.latitude(),
+                20000
+        )).thenReturn(List.of());
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "CE7",
+                center.longitude(),
+                center.latitude(),
+                20000
+        )).thenReturn(List.of());
+
+        // when
+        List<PlaceListResponse> responses =
+                placeService.getExternalPlaces(regionId);
+
+        // then
+        assertThat(responses).isEmpty();
+    }
+
+    @Test
+    @DisplayName("관광지 제외 키워드가 포함된 장소는 추가 장소 결과에서 제외한다")
+    void getExternalPlacesExcludesTourismKeyword() {
+        // given
+        Long regionId = 1L;
+
+        when(regionRepository.findById(regionId))
+                .thenReturn(Optional.of(region));
+        when(region.getLdongRegnCd()).thenReturn("44");
+        when(region.getLdongSignguCd()).thenReturn("150");
+
+        TourApiPlaceItem resort = new TourApiPlaceItem(
+                "3002",
+                "공주리조트",
+                "충청남도 공주시",
+                "36.4500000",
+                "127.1200000",
+                null,
+                "44",
+                "150",
+                "VE",
+                "VE01",
+                "VE010100",
+                null
+        );
+
+        when(tourApiPlaceClient.getPlacesByRegion("44", "150"))
+                .thenReturn(List.of(resort));
+
+        RegionCenterProvider.RegionCenter center =
+                new RegionCenterProvider.RegionCenter(
+                        new BigDecimal("127.1190"),
+                        new BigDecimal("36.4465")
+                );
+
+        when(regionCenterProvider.getCenter(region))
+                .thenReturn(center);
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "FD6",
+                center.longitude(),
+                center.latitude(),
+                20000
+        )).thenReturn(List.of());
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "CE7",
+                center.longitude(),
+                center.latitude(),
+                20000
+        )).thenReturn(List.of());
+
+        // when
+        List<PlaceListResponse> responses =
+                placeService.getExternalPlaces(regionId);
+
+        // then
+        assertThat(responses).isEmpty();
     }
 
     @Test
@@ -289,7 +631,7 @@ class PlaceServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 regionId로 추가 추천 장소를 조회하면 예외가 발생한다")
+    @DisplayName("존재하지 않는 regionId로 추가 장소를 조회하면 예외가 발생한다")
     void getExternalPlacesWithInvalidRegion() {
         // given
         Long regionId = 999L;
@@ -304,6 +646,8 @@ class PlaceServiceTest {
 
         verify(regionRepository).findById(regionId);
         verifyNoInteractions(tourApiPlaceClient);
+        verifyNoInteractions(kakaoLocalClient);
+        verifyNoInteractions(regionCenterProvider);
     }
 
     private void mockPlaceForListResponse() {
@@ -353,6 +697,57 @@ class PlaceServiceTest {
                 "HS01",
                 "HS010100",
                 "TourAPI 공산성 소개 문구입니다."
+        );
+    }
+
+    private TourApiPlaceItem createTourismItem() {
+        return new TourApiPlaceItem(
+                "2001",
+                "공산성",
+                "충청남도 공주시 웅진로 280",
+                "36.4623000",
+                "127.1248000",
+                "https://example.com/tourism.jpg",
+                "44",
+                "150",
+                "HS",
+                "HS01",
+                "HS010100",
+                null
+        );
+    }
+
+    private TourApiPlaceItem createFoodItem() {
+        return new TourApiPlaceItem(
+                "2002",
+                "공주 음식점",
+                "충청남도 공주시 중동",
+                "36.4500000",
+                "127.1200000",
+                null,
+                "44",
+                "150",
+                "FD",
+                "FD01",
+                "FD010100",
+                null
+        );
+    }
+
+    private TourApiPlaceItem createCafeItem() {
+        return new TourApiPlaceItem(
+                "2003",
+                "공주 카페",
+                "충청남도 공주시 중동",
+                "36.4510000",
+                "127.1210000",
+                null,
+                "44",
+                "150",
+                "FD",
+                "FD05",
+                "FD050100",
+                null
         );
     }
 }

--- a/src/test/java/com/chaerok/backend/place/service/PlaceServiceTest.java
+++ b/src/test/java/com/chaerok/backend/place/service/PlaceServiceTest.java
@@ -412,6 +412,34 @@ class PlaceServiceTest {
     }
 
     @Test
+    @DisplayName("지원하지 않는 지역이면 Kakao 보완 없이 TourAPI 결과만 반환한다")
+    void getExternalPlacesSkipsKakaoWhenRegionCenterIsMissing() {
+        // given
+        Long regionId = 1L;
+
+        when(regionRepository.findById(regionId))
+                .thenReturn(Optional.of(region));
+        when(region.getLdongRegnCd()).thenReturn("44");
+        when(region.getLdongSignguCd()).thenReturn("999");
+
+        when(tourApiPlaceClient.getPlacesByRegion("44", "999"))
+                .thenReturn(List.of(createTourismItem()));
+
+        when(regionCenterProvider.getCenter(region))
+                .thenReturn(null);
+
+        // when
+        List<PlaceListResponse> responses =
+                placeService.getExternalPlaces(regionId);
+
+        // then
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).title()).isEqualTo("공산성");
+
+        verifyNoInteractions(kakaoLocalClient);
+    }
+
+    @Test
     @DisplayName("지원하지 않는 TourAPI 분류 장소는 추가 장소 결과에서 제외한다")
     void getExternalPlacesExcludesUnsupportedTourApiCategory() {
         // given

--- a/src/test/java/com/chaerok/backend/place/service/RegionCenterProviderTest.java
+++ b/src/test/java/com/chaerok/backend/place/service/RegionCenterProviderTest.java
@@ -1,0 +1,110 @@
+package com.chaerok.backend.place.service;
+
+import com.chaerok.backend.region.entity.Region;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RegionCenterProviderTest {
+
+    private RegionCenterProvider regionCenterProvider;
+    private Region region;
+
+    @BeforeEach
+    void setUp() {
+        regionCenterProvider = new RegionCenterProvider();
+        region = mock(Region.class);
+    }
+
+    @Test
+    @DisplayName("공주시 시군 코드에 해당하는 중심 좌표를 반환한다")
+    void getGongjuCenter() {
+        // given
+        when(region.getLdongSignguCd()).thenReturn("150");
+
+        // when
+        RegionCenterProvider.RegionCenter center =
+                regionCenterProvider.getCenter(region);
+
+        // then
+        assertThat(center).isNotNull();
+        assertThat(center.longitude())
+                .isEqualByComparingTo(new BigDecimal("127.1190"));
+        assertThat(center.latitude())
+                .isEqualByComparingTo(new BigDecimal("36.4465"));
+    }
+
+    @Test
+    @DisplayName("부여군 시군 코드에 해당하는 중심 좌표를 반환한다")
+    void getBuyeoCenter() {
+        // given
+        when(region.getLdongSignguCd()).thenReturn("760");
+
+        // when
+        RegionCenterProvider.RegionCenter center =
+                regionCenterProvider.getCenter(region);
+
+        // then
+        assertThat(center).isNotNull();
+        assertThat(center.longitude())
+                .isEqualByComparingTo(new BigDecimal("126.9119"));
+        assertThat(center.latitude())
+                .isEqualByComparingTo(new BigDecimal("36.2757"));
+    }
+
+    @Test
+    @DisplayName("서산시 시군 코드에 해당하는 중심 좌표를 반환한다")
+    void getSeosanCenter() {
+        // given
+        when(region.getLdongSignguCd()).thenReturn("210");
+
+        // when
+        RegionCenterProvider.RegionCenter center =
+                regionCenterProvider.getCenter(region);
+
+        // then
+        assertThat(center).isNotNull();
+        assertThat(center.longitude())
+                .isEqualByComparingTo(new BigDecimal("126.4503"));
+        assertThat(center.latitude())
+                .isEqualByComparingTo(new BigDecimal("36.7845"));
+    }
+
+    @Test
+    @DisplayName("예산군 시군 코드에 해당하는 중심 좌표를 반환한다")
+    void getYesanCenter() {
+        // given
+        when(region.getLdongSignguCd()).thenReturn("810");
+
+        // when
+        RegionCenterProvider.RegionCenter center =
+                regionCenterProvider.getCenter(region);
+
+        // then
+        assertThat(center).isNotNull();
+        assertThat(center.longitude())
+                .isEqualByComparingTo(new BigDecimal("126.8447"));
+        assertThat(center.latitude())
+                .isEqualByComparingTo(new BigDecimal("36.6829"));
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 시군 코드는 중심 좌표를 반환하지 않는다")
+    void getUnsupportedRegionCenter() {
+        // given
+        when(region.getLdongSignguCd()).thenReturn("999");
+
+        // when
+        RegionCenterProvider.RegionCenter center =
+                regionCenterProvider.getCenter(region);
+
+        // then
+        assertThat(center).isNull();
+    }
+}


### PR DESCRIPTION
## ✨ 변경 사항

- 지역 추가 장소 조회 API 개선
- TourAPI 지역 장소 전체 페이지 조회 및 전체 조회 시간 제한 적용
- 관광지·시장·음식점·카페 대상 분류 필터 적용
- 모텔·호텔·리조트·체육센터 등 비추천 관광 장소 제외
- 음식점·카페 부족 시 Kakao Local API 보완 조회
- Kakao 장소의 시·군 검증 및 TourAPI 중복 장소 제거
- 미지원 지역은 Kakao 보완 조회 없이 TourAPI 결과만 반환
- 지역 중심 좌표 공통 관리 및 장소 검색 로직 적용
- 카테고리별 최대 15개, 총 45개 장소 반환

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #56 

## 🧩 API / DB 변경 사항

- `GET /api/places/external?regionId={regionId}` 지역 추가 장소 조회 개선
- TourAPI 우선 조회 후 음식점·카페 부족분 Kakao Local API 보완
- 관광지·시장·음식점·카페 카테고리별 최대 15개 반환
- TourAPI 전체 페이지 조회 시 누적 시간 제한 적용
- 지원하지 않는 지역은 Kakao Local 보완 조회 제외
- DB 변경 없음

## ✅ 테스트

- [x] 서버 실행 확인
- [x] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- TourAPI 데이터는 실시간 조회하며 추가 장소 조회 결과는 DB에 저장하지 않음
- Kakao Local API는 음식점·카페 부족분 보완 용도로 사용
- TourAPI 시장 분류는 `SH06`만 추가 장소 후보에 포함
- TourAPI 전체 조회 제한 초과 시 조회된 부분 결과 반환
- 관련 단위 테스트 및 전체 빌드 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 관광지, 음식점, 카페 검색 결과를 TourAPI 기반으로 제공하고, 부족한 음식점·카페 결과를 Kakao Local 검색으로 보완합니다.
  * 여러 페이지의 관광지 검색 결과를 수집해 더 많은 장소를 제공합니다.
  * Kakao 장소의 주소, 좌표, 카테고리를 검색 결과에 반영합니다.

* **개선**
  * 중복 장소와 다른 지역의 장소를 제외합니다.
  * 숙박·체육시설 등 관광지 검색에서 제외할 장소를 필터링합니다.
  * 지원되는 관광 카테고리를 보다 정확하게 분류합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->