### PR TITLE
feat(place): 장소 검색 결과 분류 필터 적용

### DIFF
--- a/src/main/java/com/chaerok/backend/place/service/PlaceSearchService.java
+++ b/src/main/java/com/chaerok/backend/place/service/PlaceSearchService.java
@@ -53,6 +53,10 @@ public class PlaceSearchService {
         );
 
         return items.stream()
+                .filter(item -> PlaceCategoryMapper.isSupportedTourApiCategory(
+                        item.lclsSystm1(),
+                        item.lclsSystm3()
+                ))
                 .map(PlaceSearchResponse::fromTourApi)
                 .toList();
     }

--- a/src/test/java/com/chaerok/backend/place/service/PlaceSearchServiceTest.java
+++ b/src/test/java/com/chaerok/backend/place/service/PlaceSearchServiceTest.java
@@ -100,6 +100,71 @@ class PlaceSearchServiceTest {
     }
 
     @Test
+    @DisplayName("지원하지 않는 TourAPI 분류 장소는 검색 결과에서 제외한다")
+    void searchPlacesExcludesUnsupportedTourApiCategory() {
+        // given
+        Long regionId = 1L;
+        String keyword = "공주";
+
+        when(regionRepository.findById(regionId))
+                .thenReturn(Optional.of(region));
+        when(region.getLdongRegnCd()).thenReturn("44");
+        when(region.getLdongSignguCd()).thenReturn("150");
+
+        TourApiPlaceItem supportedItem = createTourApiItem(
+                "1001",
+                "공산성"
+        );
+
+        TourApiPlaceItem unsupportedItem = new TourApiPlaceItem(
+                "1002",
+                "일반 쇼핑 매장",
+                "충청남도 공주시",
+                "36.4623",
+                "127.1248",
+                null,
+                "44",
+                "150",
+                "SH",
+                "SH01",
+                "SH010100",
+                null
+        );
+
+        when(tourApiPlaceClient.searchPlacesByKeyword(
+                keyword,
+                "44",
+                "150"
+        )).thenReturn(List.of(
+                supportedItem,
+                unsupportedItem
+        ));
+
+        RegionCenterProvider.RegionCenter center =
+                new RegionCenterProvider.RegionCenter(
+                        new BigDecimal("127.1190"),
+                        new BigDecimal("36.4465")
+                );
+
+        when(regionCenterProvider.getCenter(region))
+                .thenReturn(center);
+
+        when(kakaoLocalClient.searchPlacesByKeyword(
+                keyword,
+                center.longitude(),
+                center.latitude()
+        )).thenReturn(List.of());
+
+        // when
+        List<PlaceSearchResponse> responses =
+                placeSearchService.searchPlaces(regionId, keyword);
+
+        // then
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).title()).isEqualTo("공산성");
+    }
+
+    @Test
     @DisplayName("TourAPI 검색 결과가 부족하면 Kakao 검색 결과로 보완한다")
     void searchPlacesSupplementsWithKakao() {
         // given


### PR DESCRIPTION
## ✨ 변경 사항

- 장소 검색 결과에 채록 지원 관광 분류 필터 적용
- TourAPI 검색 결과 중 관광지·시장·음식점·카페 분류만 반환
- 지원하지 않는 일반 쇼핑 등 불필요한 장소 제외
- 기존 TourAPI 우선 검색 및 Kakao Local 보완 흐름 유지
- PlaceSearchService 단위 테스트 보완

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #58 

## 🧩 API / DB 변경 사항

- `GET /api/places/search?regionId={regionId}&keyword={keyword}`
  - TourAPI 검색 결과에 채록 지원 관광 분류 필터 적용
  - 응답 구조 변경 없음
- DB 변경 없음

## ✅ 테스트

- [ ] 서버 실행 확인
- [ ] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- 지원 분류: 관광지 `EX`, `EV`, `HS`, `LS`, `NA`, `VE`, 시장 `SH06`, 음식점 `FD01~FD04`, 카페 `FD05`
- 기존 Kakao Local 보완 검색 로직은 변경하지 않음
- PlaceSearchService 단위 테스트 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 장소 검색 결과에서 지원되지 않는 관광 API 분류의 장소가 제외됩니다.
  * 지원되는 분류의 장소만 최종 검색 결과에 표시됩니다.

* **테스트**
  * 지원 장소와 제외 대상이 함께 검색될 때 올바르게 필터링되는지 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->