### PR TITLE
fix(render): CREATED 렌더 작업 자동 복구 보완

### DIFF
--- a/src/main/java/com/chaerok/backend/render/repository/RenderJobRepository.java
+++ b/src/main/java/com/chaerok/backend/render/repository/RenderJobRepository.java
@@ -3,11 +3,13 @@ package com.chaerok.backend.render.repository;
 import com.chaerok.backend.render.entity.RenderJob;
 import com.chaerok.backend.render.entity.RenderJobStatus;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +29,19 @@ public interface RenderJobRepository
     boolean existsByFilmRollIdAndStatusIn(
             Long filmRollId,
             Collection<RenderJobStatus> statuses
+    );
+
+    @Query("""
+            select renderJob.id
+            from RenderJob renderJob
+            where renderJob.status = :status
+              and renderJob.createdAt <= :createdBefore
+            order by renderJob.createdAt asc
+            """)
+    List<UUID> findStaleIds(
+            @Param("status") RenderJobStatus status,
+            @Param("createdBefore") LocalDateTime createdBefore,
+            Pageable pageable
     );
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/chaerok/backend/render/scheduler/RenderJobRecoveryScheduler.java
+++ b/src/main/java/com/chaerok/backend/render/scheduler/RenderJobRecoveryScheduler.java
@@ -1,0 +1,63 @@
+package com.chaerok.backend.render.scheduler;
+
+import com.chaerok.backend.render.entity.RenderJobStatus;
+import com.chaerok.backend.render.repository.RenderJobRepository;
+import com.chaerok.backend.render.service.RenderJobRecoveryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        prefix = "aws.sqs",
+        name = "render-queue-url"
+)
+public class RenderJobRecoveryScheduler {
+
+    private static final long STALE_SECONDS = 300L;
+    private static final int BATCH_SIZE = 20;
+
+    private final RenderJobRepository renderJobRepository;
+    private final RenderJobRecoveryService recoveryService;
+
+    @Scheduled(
+            fixedDelayString =
+                    "${chaerok.render.created-recovery-poll-delay-ms:60000}"
+    )
+    public void recoverStaleCreatedJobs() {
+        LocalDateTime createdBefore =
+                LocalDateTime.now()
+                        .minusSeconds(STALE_SECONDS);
+
+        List<UUID> renderJobIds =
+                renderJobRepository.findStaleIds(
+                        RenderJobStatus.CREATED,
+                        createdBefore,
+                        PageRequest.of(0, BATCH_SIZE)
+                );
+
+        for (UUID renderJobId : renderJobIds) {
+            try {
+                recoveryService.recover(
+                        renderJobId,
+                        createdBefore
+                );
+            } catch (RuntimeException exception) {
+                log.error(
+                        "CREATED 렌더링 작업 복구 처리 중 오류: renderJobId={}",
+                        renderJobId,
+                        exception
+                );
+            }
+        }
+    }
+}

--- a/src/main/java/com/chaerok/backend/render/service/RenderJobRecoveryPreparationService.java
+++ b/src/main/java/com/chaerok/backend/render/service/RenderJobRecoveryPreparationService.java
@@ -1,0 +1,169 @@
+package com.chaerok.backend.render.service;
+
+import com.chaerok.backend.filmroll.entity.FilmRoll;
+import com.chaerok.backend.filmroll.entity.FilmRollStatus;
+import com.chaerok.backend.global.aws.AwsProperties;
+import com.chaerok.backend.photo.entity.Photo;
+import com.chaerok.backend.photo.entity.PhotoStatus;
+import com.chaerok.backend.photo.repository.PhotoRepository;
+import com.chaerok.backend.render.entity.RenderJob;
+import com.chaerok.backend.render.entity.RenderJobStatus;
+import com.chaerok.backend.render.queue.RenderQueueMessage;
+import com.chaerok.backend.render.repository.RenderJobRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        prefix = "aws.sqs",
+        name = "render-queue-url"
+)
+public class RenderJobRecoveryPreparationService {
+
+    private final RenderJobRepository renderJobRepository;
+    private final PhotoRepository photoRepository;
+    private final AwsProperties awsProperties;
+
+    @Transactional
+    public Optional<PreparedRenderJob> prepare(
+            UUID renderJobId,
+            LocalDateTime createdBefore
+    ) {
+        RenderJob renderJob = renderJobRepository
+                .findByIdForUpdate(renderJobId)
+                .orElse(null);
+
+        if (renderJob == null
+                || renderJob.getStatus() != RenderJobStatus.CREATED) {
+            return Optional.empty();
+        }
+
+        LocalDateTime createdAt = renderJob.getCreatedAt();
+
+        if (createdAt == null
+                || createdAt.isAfter(createdBefore)) {
+            return Optional.empty();
+        }
+
+        FilmRoll filmRoll = renderJob.getFilmRoll();
+
+        if (filmRoll.getStatus() != FilmRollStatus.READY) {
+            throw new IllegalStateException(
+                    "CREATED 렌더링 작업의 필름 롤이 READY 상태가 아닙니다. "
+                            + "renderJobId="
+                            + renderJobId
+                            + ", filmRollStatus="
+                            + filmRoll.getStatus()
+            );
+        }
+
+        List<Photo> photos =
+                photoRepository
+                        .findAllByFilmRollIdOrderBySequenceAsc(
+                                filmRoll.getId()
+                        );
+
+        validatePhotos(filmRoll, photos);
+
+        RenderQueueMessage message =
+                createMessage(
+                        renderJob,
+                        filmRoll,
+                        photos,
+                        createdAt
+                );
+
+        return Optional.of(
+                new PreparedRenderJob(
+                        renderJob.getId(),
+                        filmRoll.getId(),
+                        filmRoll.getUser().getId(),
+                        message
+                )
+        );
+    }
+
+    private void validatePhotos(
+            FilmRoll filmRoll,
+            List<Photo> photos
+    ) {
+        if (photos.isEmpty()) {
+            throw new IllegalStateException(
+                    "CREATED 렌더링 작업에 현상할 사진이 없습니다."
+            );
+        }
+
+        if (photos.size() != filmRoll.getTotalPhotoCount()) {
+            throw new IllegalStateException(
+                    "CREATED 렌더링 작업의 사진 수가 일치하지 않습니다."
+            );
+        }
+
+        for (int index = 0; index < photos.size(); index++) {
+            Photo photo = photos.get(index);
+            int expectedSequence = index + 1;
+
+            if (!Integer.valueOf(expectedSequence)
+                    .equals(photo.getSequence())) {
+                throw new IllegalStateException(
+                        "CREATED 렌더링 작업의 사진 순서가 올바르지 않습니다."
+                );
+            }
+
+            if (photo.getStatus() != PhotoStatus.UPLOADED) {
+                throw new IllegalStateException(
+                        "CREATED 렌더링 작업에 업로드 완료되지 않은 사진이 있습니다."
+                );
+            }
+
+            if (photo.getOriginalObjectKey() == null
+                    || photo.getOriginalObjectKey().isBlank()) {
+                throw new IllegalStateException(
+                        "CREATED 렌더링 작업의 원본 객체 키가 없습니다."
+                );
+            }
+        }
+    }
+
+    private RenderQueueMessage createMessage(
+            RenderJob renderJob,
+            FilmRoll filmRoll,
+            List<Photo> photos,
+            LocalDateTime requestedAt
+    ) {
+        List<RenderQueueMessage.PhotoItem> photoItems =
+                photos.stream()
+                        .map(photo ->
+                                new RenderQueueMessage.PhotoItem(
+                                        photo.getId(),
+                                        photo.getSequence(),
+                                        photo.getOriginalObjectKey(),
+                                        photo.getTakenAt()
+                                )
+                        )
+                        .toList();
+
+        return new RenderQueueMessage(
+                RenderQueueMessage.CURRENT_SCHEMA_VERSION,
+                renderJob.getId(),
+                filmRoll.getId(),
+                filmRoll.getUser().getId(),
+                filmRoll.getRegion().getId(),
+                awsProperties.getS3().getBucket(),
+                filmRoll.getFilterId(),
+                filmRoll.getFilterStrength(),
+                filmRoll.getFilterVersion(),
+                filmRoll.getTotalPhotoCount(),
+                requestedAt,
+                photoItems
+        );
+    }
+}

--- a/src/main/java/com/chaerok/backend/render/service/RenderJobRecoveryService.java
+++ b/src/main/java/com/chaerok/backend/render/service/RenderJobRecoveryService.java
@@ -1,0 +1,86 @@
+package com.chaerok.backend.render.service;
+
+import com.chaerok.backend.render.queue.RenderQueuePublishResult;
+import com.chaerok.backend.render.queue.RenderQueuePublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        prefix = "aws.sqs",
+        name = "render-queue-url"
+)
+public class RenderJobRecoveryService {
+
+    private final RenderJobRecoveryPreparationService preparationService;
+    private final RenderQueuePublisher queuePublisher;
+    private final RenderJobStateService stateService;
+
+    public void recover(
+            UUID renderJobId,
+            LocalDateTime createdBefore
+    ) {
+        Optional<PreparedRenderJob> preparedOptional =
+                preparationService.prepare(
+                        renderJobId,
+                        createdBefore
+                );
+
+        if (preparedOptional.isEmpty()) {
+            return;
+        }
+
+        PreparedRenderJob prepared =
+                preparedOptional.get();
+
+        RenderQueuePublishResult publishResult;
+
+        try {
+            publishResult =
+                    queuePublisher.publish(
+                            prepared.message()
+                    );
+        } catch (RuntimeException exception) {
+            stateService.markQueueFailed(
+                    prepared.renderJobId(),
+                    exception
+            );
+
+            log.warn(
+                    "CREATED 렌더링 작업 SQS 재발행 실패: renderJobId={}, filmRollId={}, error={}",
+                    prepared.renderJobId(),
+                    prepared.filmRollId(),
+                    exception.getMessage()
+            );
+            return;
+        }
+
+        /*
+         * SQS 재발행은 이미 성공했습니다.
+         *
+         * QUEUED 기록이 실패했다고 해서
+         * SQS_SEND_FAILED로 상태를 덮어쓰지 않습니다.
+         */
+        stateService.markQueued(
+                prepared.renderJobId(),
+                prepared.filmRollId(),
+                prepared.userId(),
+                publishResult
+        );
+
+        log.info(
+                "CREATED 렌더링 작업 SQS 복구 완료: renderJobId={}, filmRollId={}, messageId={}",
+                prepared.renderJobId(),
+                prepared.filmRollId(),
+                publishResult.messageId()
+        );
+    }
+}

--- a/src/main/java/com/chaerok/backend/render/service/RenderRequestService.java
+++ b/src/main/java/com/chaerok/backend/render/service/RenderRequestService.java
@@ -23,29 +23,19 @@ public class RenderRequestService {
             Long userId,
             Long filmRollId
     ) {
-        /*
-         * 1) DB 트랜잭션을 먼저 커밋해 RenderJob(CREATED)을 보존합니다.
-         * 2) DB 트랜잭션 밖에서 SQS에 전송합니다.
-         * 3) 별도 트랜잭션으로 성공/실패 상태를 기록합니다.
-         */
         PreparedRenderJob prepared =
                 preparationService.prepare(
                         userId,
                         filmRollId
                 );
 
+        RenderQueuePublishResult publishResult;
+
         try {
-            RenderQueuePublishResult publishResult =
+            publishResult =
                     queuePublisher.publish(
                             prepared.message()
                     );
-
-            return stateService.markQueued(
-                    prepared.renderJobId(),
-                    prepared.filmRollId(),
-                    prepared.userId(),
-                    publishResult
-            );
         } catch (RuntimeException exception) {
             stateService.markQueueFailed(
                     prepared.renderJobId(),
@@ -54,5 +44,21 @@ public class RenderRequestService {
 
             throw exception;
         }
+
+        /*
+         * 여기까지 왔으면 SQS 전송은 이미 성공했습니다.
+         *
+         * 따라서 아래 QUEUED DB 기록이 실패하더라도
+         * SQS_SEND_FAILED로 기록하면 안 됩니다.
+         *
+         * CREATED로 남은 작업은 결과 메시지 또는
+         * CREATED recovery가 다시 처리할 수 있습니다.
+         */
+        return stateService.markQueued(
+                prepared.renderJobId(),
+                prepared.filmRollId(),
+                prepared.userId(),
+                publishResult
+        );
     }
 }

--- a/src/test/java/com/chaerok/backend/render/scheduler/RenderJobRecoverySchedulerTest.java
+++ b/src/test/java/com/chaerok/backend/render/scheduler/RenderJobRecoverySchedulerTest.java
@@ -1,0 +1,102 @@
+package com.chaerok.backend.render.scheduler;
+
+import com.chaerok.backend.render.entity.RenderJobStatus;
+import com.chaerok.backend.render.repository.RenderJobRepository;
+import com.chaerok.backend.render.service.RenderJobRecoveryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RenderJobRecoverySchedulerTest {
+
+    @Mock
+    private RenderJobRepository renderJobRepository;
+
+    @Mock
+    private RenderJobRecoveryService recoveryService;
+
+    @Test
+    @DisplayName("오래된 CREATED 작업을 조회해 복구 서비스에 전달한다")
+    void recoversStaleCreatedJobs() {
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+
+        when(renderJobRepository.findStaleIds(
+                eq(RenderJobStatus.CREATED),
+                any(LocalDateTime.class),
+                any(Pageable.class)
+        )).thenReturn(
+                List.of(first, second)
+        );
+
+        RenderJobRecoveryScheduler scheduler =
+                new RenderJobRecoveryScheduler(
+                        renderJobRepository,
+                        recoveryService
+                );
+
+        scheduler.recoverStaleCreatedJobs();
+
+        verify(recoveryService)
+                .recover(
+                        eq(first),
+                        any(LocalDateTime.class)
+                );
+
+        verify(recoveryService)
+                .recover(
+                        eq(second),
+                        any(LocalDateTime.class)
+                );
+    }
+
+    @Test
+    @DisplayName("한 작업 복구가 실패해도 다음 CREATED 작업을 계속 처리한다")
+    void continuesAfterIndividualFailure() {
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+
+        when(renderJobRepository.findStaleIds(
+                eq(RenderJobStatus.CREATED),
+                any(LocalDateTime.class),
+                any(Pageable.class)
+        )).thenReturn(
+                List.of(first, second)
+        );
+
+        doThrow(new RuntimeException("first failure"))
+                .when(recoveryService)
+                .recover(
+                        eq(first),
+                        any(LocalDateTime.class)
+                );
+
+        RenderJobRecoveryScheduler scheduler =
+                new RenderJobRecoveryScheduler(
+                        renderJobRepository,
+                        recoveryService
+                );
+
+        scheduler.recoverStaleCreatedJobs();
+
+        verify(recoveryService)
+                .recover(
+                        eq(second),
+                        any(LocalDateTime.class)
+                );
+    }
+}

--- a/src/test/java/com/chaerok/backend/render/service/RenderJobRecoveryPreparationServiceTest.java
+++ b/src/test/java/com/chaerok/backend/render/service/RenderJobRecoveryPreparationServiceTest.java
@@ -1,0 +1,252 @@
+package com.chaerok.backend.render.service;
+
+import com.chaerok.backend.filmroll.entity.FilmRoll;
+import com.chaerok.backend.filmroll.entity.FilmRollStatus;
+import com.chaerok.backend.global.aws.AwsProperties;
+import com.chaerok.backend.photo.entity.Photo;
+import com.chaerok.backend.photo.entity.PhotoStatus;
+import com.chaerok.backend.photo.repository.PhotoRepository;
+import com.chaerok.backend.region.entity.Region;
+import com.chaerok.backend.render.entity.RenderJob;
+import com.chaerok.backend.render.entity.RenderJobStatus;
+import com.chaerok.backend.render.repository.RenderJobRepository;
+import com.chaerok.backend.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RenderJobRecoveryPreparationServiceTest {
+
+    @Mock
+    private RenderJobRepository renderJobRepository;
+
+    @Mock
+    private PhotoRepository photoRepository;
+
+    @Mock
+    private RenderJob renderJob;
+
+    @Mock
+    private FilmRoll filmRoll;
+
+    @Mock
+    private Photo photo;
+
+    @Mock
+    private User user;
+
+    @Mock
+    private Region region;
+
+    private RenderJobRecoveryPreparationService service;
+
+    @BeforeEach
+    void setUp() {
+        AwsProperties awsProperties = new AwsProperties();
+        awsProperties.getS3().setBucket("bucket");
+
+        service = new RenderJobRecoveryPreparationService(
+                renderJobRepository,
+                photoRepository,
+                awsProperties
+        );
+    }
+
+    @Test
+    @DisplayName("5분 이상 CREATED 작업은 같은 renderJobId로 SQS 메시지를 복구한다")
+    void preparesStaleCreatedJob() {
+        UUID renderJobId = UUID.randomUUID();
+
+        LocalDateTime createdAt =
+                LocalDateTime.of(2026, 8, 27, 15, 0);
+
+        LocalDateTime createdBefore =
+                LocalDateTime.of(2026, 8, 27, 15, 5);
+
+        LocalDateTime takenAt =
+                LocalDateTime.of(2026, 8, 27, 14, 50);
+
+        when(renderJobRepository.findByIdForUpdate(renderJobId))
+                .thenReturn(Optional.of(renderJob));
+
+        when(renderJob.getStatus())
+                .thenReturn(RenderJobStatus.CREATED);
+
+        when(renderJob.getCreatedAt())
+                .thenReturn(createdAt);
+
+        when(renderJob.getFilmRoll())
+                .thenReturn(filmRoll);
+
+        when(renderJob.getId())
+                .thenReturn(renderJobId);
+
+        when(filmRoll.getStatus())
+                .thenReturn(FilmRollStatus.READY);
+
+        when(filmRoll.getId())
+                .thenReturn(2L);
+
+        when(filmRoll.getTotalPhotoCount())
+                .thenReturn(1);
+
+        when(filmRoll.getUser())
+                .thenReturn(user);
+
+        when(user.getId())
+                .thenReturn(6L);
+
+        when(filmRoll.getRegion())
+                .thenReturn(region);
+
+        when(region.getId())
+                .thenReturn(1L);
+
+        when(filmRoll.getFilterId())
+                .thenReturn("gongju");
+
+        when(filmRoll.getFilterStrength())
+                .thenReturn(0.8);
+
+        when(filmRoll.getFilterVersion())
+                .thenReturn(1);
+
+        when(photoRepository
+                .findAllByFilmRollIdOrderBySequenceAsc(2L))
+                .thenReturn(List.of(photo));
+
+        when(photo.getId())
+                .thenReturn(10L);
+
+        when(photo.getSequence())
+                .thenReturn(1);
+
+        when(photo.getStatus())
+                .thenReturn(PhotoStatus.UPLOADED);
+
+        when(photo.getOriginalObjectKey())
+                .thenReturn(
+                        "users/6/rolls/2/original/001.jpg"
+                );
+
+        when(photo.getTakenAt())
+                .thenReturn(takenAt);
+
+        Optional<PreparedRenderJob> result =
+                service.prepare(
+                        renderJobId,
+                        createdBefore
+                );
+
+        assertThat(result).isPresent();
+
+        PreparedRenderJob prepared = result.orElseThrow();
+
+        assertThat(prepared.renderJobId())
+                .isEqualTo(renderJobId);
+
+        assertThat(prepared.filmRollId())
+                .isEqualTo(2L);
+
+        assertThat(prepared.userId())
+                .isEqualTo(6L);
+
+        assertThat(prepared.message().renderJobId())
+                .isEqualTo(renderJobId);
+
+        assertThat(prepared.message().filmRollId())
+                .isEqualTo(2L);
+
+        assertThat(prepared.message().bucket())
+                .isEqualTo("bucket");
+
+        assertThat(prepared.message().filterId())
+                .isEqualTo("gongju");
+
+        assertThat(prepared.message().requestedAt())
+                .isEqualTo(createdAt);
+
+        assertThat(prepared.message().photos())
+                .hasSize(1);
+
+        assertThat(prepared.message().photos().get(0).photoId())
+                .isEqualTo(10L);
+
+        assertThat(prepared.message().photos().get(0).sequence())
+                .isEqualTo(1);
+
+        assertThat(
+                prepared.message()
+                        .photos()
+                        .get(0)
+                        .originalObjectKey()
+        ).isEqualTo(
+                "users/6/rolls/2/original/001.jpg"
+        );
+    }
+
+    @Test
+    @DisplayName("CREATED가 아닌 작업은 복구하지 않는다")
+    void skipsNonCreatedJob() {
+        UUID renderJobId = UUID.randomUUID();
+
+        when(renderJobRepository.findByIdForUpdate(renderJobId))
+                .thenReturn(Optional.of(renderJob));
+
+        when(renderJob.getStatus())
+                .thenReturn(RenderJobStatus.QUEUED);
+
+        Optional<PreparedRenderJob> result =
+                service.prepare(
+                        renderJobId,
+                        LocalDateTime.now()
+                );
+
+        assertThat(result).isEmpty();
+
+        verifyNoInteractions(photoRepository);
+    }
+
+    @Test
+    @DisplayName("아직 stale 기준 시간이 지나지 않은 CREATED 작업은 복구하지 않는다")
+    void skipsFreshCreatedJob() {
+        UUID renderJobId = UUID.randomUUID();
+
+        LocalDateTime createdBefore =
+                LocalDateTime.of(2026, 8, 27, 15, 0);
+
+        when(renderJobRepository.findByIdForUpdate(renderJobId))
+                .thenReturn(Optional.of(renderJob));
+
+        when(renderJob.getStatus())
+                .thenReturn(RenderJobStatus.CREATED);
+
+        when(renderJob.getCreatedAt())
+                .thenReturn(
+                        createdBefore.plusSeconds(1)
+                );
+
+        Optional<PreparedRenderJob> result =
+                service.prepare(
+                        renderJobId,
+                        createdBefore
+                );
+
+        assertThat(result).isEmpty();
+
+        verifyNoInteractions(photoRepository);
+    }
+}

--- a/src/test/java/com/chaerok/backend/render/service/RenderJobRecoveryServiceTest.java
+++ b/src/test/java/com/chaerok/backend/render/service/RenderJobRecoveryServiceTest.java
@@ -1,33 +1,29 @@
 package com.chaerok.backend.render.service;
 
-import com.chaerok.backend.render.dto.RenderRequestResponse;
 import com.chaerok.backend.render.queue.RenderQueueMessage;
 import com.chaerok.backend.render.queue.RenderQueuePublishResult;
 import com.chaerok.backend.render.queue.RenderQueuePublisher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class RenderRequestServiceTest {
+class RenderJobRecoveryServiceTest {
 
     @Mock
-    private RenderJobPreparationService preparationService;
+    private RenderJobRecoveryPreparationService preparationService;
 
     @Mock
     private RenderQueuePublisher queuePublisher;
@@ -36,24 +32,28 @@ class RenderRequestServiceTest {
     private RenderJobStateService stateService;
 
     @Test
-    @DisplayName("DB 준비 후 SQS 전송과 QUEUED 전환을 순서대로 수행한다")
-    void requestRender() {
+    @DisplayName("stale CREATED 작업을 같은 메시지로 재발행하고 QUEUED 처리한다")
+    void recoversCreatedJob() {
         UUID renderJobId = UUID.randomUUID();
 
-        RenderQueueMessage message = new RenderQueueMessage(
-                RenderQueueMessage.CURRENT_SCHEMA_VERSION,
-                renderJobId,
-                2L,
-                6L,
-                1L,
-                "bucket",
-                "gongju",
-                0.8,
-                1,
-                1,
-                LocalDateTime.now(),
-                List.of()
-        );
+        LocalDateTime cutoff =
+                LocalDateTime.of(2026, 8, 27, 15, 0);
+
+        RenderQueueMessage message =
+                new RenderQueueMessage(
+                        RenderQueueMessage.CURRENT_SCHEMA_VERSION,
+                        renderJobId,
+                        2L,
+                        6L,
+                        1L,
+                        "bucket",
+                        "gongju",
+                        0.8,
+                        1,
+                        1,
+                        cutoff.minusMinutes(10),
+                        List.of()
+                );
 
         PreparedRenderJob prepared =
                 new PreparedRenderJob(
@@ -65,50 +65,33 @@ class RenderRequestServiceTest {
 
         RenderQueuePublishResult publishResult =
                 new RenderQueuePublishResult(
-                        "message-123"
+                        "recovered-message-id"
                 );
 
-        RenderRequestResponse expected =
-                mock(RenderRequestResponse.class);
-
-        when(preparationService.prepare(6L, 2L))
-                .thenReturn(prepared);
+        when(preparationService.prepare(
+                renderJobId,
+                cutoff
+        )).thenReturn(Optional.of(prepared));
 
         when(queuePublisher.publish(message))
                 .thenReturn(publishResult);
 
-        when(stateService.markQueued(
-                renderJobId,
-                2L,
-                6L,
-                publishResult
-        )).thenReturn(expected);
-
-        RenderRequestService service =
-                new RenderRequestService(
+        RenderJobRecoveryService service =
+                new RenderJobRecoveryService(
                         preparationService,
                         queuePublisher,
                         stateService
                 );
 
-        RenderRequestResponse actual =
-                service.requestRender(6L, 2L);
-
-        assertThat(actual).isSameAs(expected);
-
-        InOrder inOrder = inOrder(
-                preparationService,
-                queuePublisher,
-                stateService
+        service.recover(
+                renderJobId,
+                cutoff
         );
 
-        inOrder.verify(preparationService)
-                .prepare(6L, 2L);
-
-        inOrder.verify(queuePublisher)
+        verify(queuePublisher)
                 .publish(message);
 
-        inOrder.verify(stateService)
+        verify(stateService)
                 .markQueued(
                         renderJobId,
                         2L,
@@ -124,24 +107,57 @@ class RenderRequestServiceTest {
     }
 
     @Test
-    @DisplayName("SQS 전송 실패 시 QUEUE_FAILED 상태 기록을 요청한다")
-    void markQueueFailedWhenPublishingFails() {
+    @DisplayName("복구 대상이 아니면 SQS를 호출하지 않는다")
+    void skipsWhenPreparationReturnsEmpty() {
+        UUID renderJobId = UUID.randomUUID();
+        LocalDateTime cutoff = LocalDateTime.now();
+
+        when(preparationService.prepare(
+                renderJobId,
+                cutoff
+        )).thenReturn(Optional.empty());
+
+        RenderJobRecoveryService service =
+                new RenderJobRecoveryService(
+                        preparationService,
+                        queuePublisher,
+                        stateService
+                );
+
+        service.recover(
+                renderJobId,
+                cutoff
+        );
+
+        verifyNoInteractions(
+                queuePublisher,
+                stateService
+        );
+    }
+
+    @Test
+    @DisplayName("복구 SQS 재발행 실패 시 QUEUE_FAILED를 기록한다")
+    void marksQueueFailedWhenRepublishFails() {
         UUID renderJobId = UUID.randomUUID();
 
-        RenderQueueMessage message = new RenderQueueMessage(
-                RenderQueueMessage.CURRENT_SCHEMA_VERSION,
-                renderJobId,
-                2L,
-                6L,
-                1L,
-                "bucket",
-                "gongju",
-                0.8,
-                1,
-                1,
-                LocalDateTime.now(),
-                List.of()
-        );
+        LocalDateTime cutoff =
+                LocalDateTime.of(2026, 8, 27, 15, 0);
+
+        RenderQueueMessage message =
+                new RenderQueueMessage(
+                        RenderQueueMessage.CURRENT_SCHEMA_VERSION,
+                        renderJobId,
+                        2L,
+                        6L,
+                        1L,
+                        "bucket",
+                        "gongju",
+                        0.8,
+                        1,
+                        1,
+                        cutoff.minusMinutes(10),
+                        List.of()
+                );
 
         PreparedRenderJob prepared =
                 new PreparedRenderJob(
@@ -152,24 +168,27 @@ class RenderRequestServiceTest {
                 );
 
         RuntimeException failure =
-                new RuntimeException("SQS failure");
+                new RuntimeException("SQS unavailable");
 
-        when(preparationService.prepare(6L, 2L))
-                .thenReturn(prepared);
+        when(preparationService.prepare(
+                renderJobId,
+                cutoff
+        )).thenReturn(Optional.of(prepared));
 
         when(queuePublisher.publish(message))
                 .thenThrow(failure);
 
-        RenderRequestService service =
-                new RenderRequestService(
+        RenderJobRecoveryService service =
+                new RenderJobRecoveryService(
                         preparationService,
                         queuePublisher,
                         stateService
                 );
 
-        assertThatThrownBy(() ->
-                service.requestRender(6L, 2L)
-        ).isSameAs(failure);
+        service.recover(
+                renderJobId,
+                cutoff
+        );
 
         verify(stateService)
                 .markQueueFailed(
@@ -187,9 +206,18 @@ class RenderRequestServiceTest {
     }
 
     @Test
-    @DisplayName("SQS 전송 성공 후 QUEUED 기록 실패는 QUEUE_FAILED로 오기록하지 않는다")
-    void doesNotMarkQueueFailedWhenQueuedWriteFails() {
+    @DisplayName("SQS 재발행 성공 후 QUEUED 기록 실패는 QUEUE_FAILED로 오기록하지 않는다")
+    void doesNotMarkQueueFailedWhenRecoveryQueuedWriteFails() {
         UUID renderJobId = UUID.randomUUID();
+
+        LocalDateTime cutoff =
+                LocalDateTime.of(
+                        2026,
+                        8,
+                        27,
+                        15,
+                        0
+                );
 
         RenderQueueMessage message =
                 new RenderQueueMessage(
@@ -203,7 +231,7 @@ class RenderRequestServiceTest {
                         0.8,
                         1,
                         1,
-                        LocalDateTime.now(),
+                        cutoff.minusMinutes(10),
                         List.of()
                 );
 
@@ -217,7 +245,7 @@ class RenderRequestServiceTest {
 
         RenderQueuePublishResult publishResult =
                 new RenderQueuePublishResult(
-                        "message-success"
+                        "recovery-message-success"
                 );
 
         RuntimeException dbFailure =
@@ -225,8 +253,12 @@ class RenderRequestServiceTest {
                         "QUEUED DB write failed"
                 );
 
-        when(preparationService.prepare(6L, 2L))
-                .thenReturn(prepared);
+        when(preparationService.prepare(
+                renderJobId,
+                cutoff
+        )).thenReturn(
+                Optional.of(prepared)
+        );
 
         when(queuePublisher.publish(message))
                 .thenReturn(publishResult);
@@ -238,16 +270,21 @@ class RenderRequestServiceTest {
                 publishResult
         )).thenThrow(dbFailure);
 
-        RenderRequestService service =
-                new RenderRequestService(
+        RenderJobRecoveryService service =
+                new RenderJobRecoveryService(
                         preparationService,
                         queuePublisher,
                         stateService
                 );
 
-        assertThatThrownBy(() ->
-                service.requestRender(6L, 2L)
-        ).isSameAs(dbFailure);
+        org.assertj.core.api.Assertions
+                .assertThatThrownBy(() ->
+                        service.recover(
+                                renderJobId,
+                                cutoff
+                        )
+                )
+                .isSameAs(dbFailure);
 
         verify(stateService, never())
                 .markQueueFailed(


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 핵심적으로 변경된 사항을 간단히 작성해주세요. -->

- 장시간 `CREATED` 상태에 머무는 RenderJob 자동 복구 로직 추가
- 5분 이상 지난 `CREATED` 작업을 주기적으로 탐색하도록 Recovery Scheduler 추가
- 기존 `renderJobId`를 유지한 채 SQS 메시지를 재구성하여 재발행
- Recovery 전 FilmRoll / Photo 상태 재검증
- SQS 전송 실패와 `QUEUED` DB 기록 실패를 구분하여 상태 오기록 방지
- RenderJob Recovery 단위 테스트 및 회귀 테스트 추가

## 📌 담당 영역
<!-- 해당하는 항목에 체크해주세요. -->

- [ ] 공통 설정 / 인프라
- [ ] Backend 1: 사용자·관광 데이터·코스/Odii
- [x] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈
<!-- 예: closes #1 -->

- closes #이슈번호

## 🧩 API / DB 변경 사항
<!-- API, 테이블, 컬럼, Storage 변경이 있으면 작성해주세요. 없으면 "없음" -->

- Public API 변경 없음
- DB 테이블 / 컬럼 변경 없음
- Flyway Migration 추가 없음

## ✅ 테스트

- [x] 서버 실행 확인
- [x] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항
<!-- 리뷰어가 알아야 할 내용이 있다면 작성해주세요. -->

- 복구 기준은 5분 이상 `CREATED` 상태로 유지된 RenderJob
- Recovery Scheduler 기본 실행 주기는 1분
- 복구 시 새로운 RenderJob을 생성하지 않고 기존 `renderJobId`를 유지
- 전체 Spring 테스트 `clean test` 통과
- 실제 AWS SQS / Lambda 기반 Recovery E2E 검증 완료
- 의도적으로 stale `CREATED` RenderJob을 생성한 뒤 아래 상태 전이를 확인함

  `READY → PROCESSING → COMPLETED`

- 필터 이미지 / ZIP / Reel 결과 생성 확인