### PR TITLE
fix(config): Spring 컨테이너 시간대 Asia/Seoul로 고정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ COPY --from=builder /app/build/libs/*.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]


### PR DESCRIPTION
## ✨ 변경 사항

- Spring 컨테이너 JVM 기본 시간대를 `Asia/Seoul`로 고정
- 실행 환경에 따라 `LocalDateTime.now()` 및 Hibernate timestamp가 UTC/KST로 혼용되는 문제 보완
- 알림 Outbox에서 `occurred_at`과 `sent_at`이 약 9시간 차이나는 현상 대응

## 📌 담당 영역

- [x] 공통 설정 / 인프라
- [ ] Backend 1: 사용자·관광 데이터·코스/Odii
- [x] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- 없음

## 🧩 API / DB 변경 사항

- API 변경 없음
- DB 스키마 변경 없음
- Docker 실행 옵션에 `-Duser.timezone=Asia/Seoul` 추가

## ✅ 테스트

- [x] 서버 테스트 확인
- [ ] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

### 추가 검증

- `.\gradlew.bat test` 성공
- Docker 이미지 빌드 성공
- Docker image inspect 결과 확인
  - `["java","-Duser.timezone=Asia/Seoul","-jar","app.jar"]`

## 💬 참고 사항

실제 E2E 중 `notification_outbox`에서 같은 이벤트의 시간값이 KST/UTC로 혼용되는 현상을 확인했습니다.

예:
- `occurred_at`: 18시대
- `sent_at`: 09시대

Spring 컨테이너의 JVM 기본 시간대를 명시적으로 `Asia/Seoul`로 고정해 환경별 시간대 차이를 제거합니다.