### PR TITLE
refactor(course): 외부 API 호출과 트랜잭션 분리

### DIFF
--- a/src/main/java/com/chaerok/backend/course/service/CourseCommandService.java
+++ b/src/main/java/com/chaerok/backend/course/service/CourseCommandService.java
@@ -5,20 +5,10 @@ import com.chaerok.backend.course.dto.CourseCreateRequest;
 import com.chaerok.backend.course.dto.CoursePlaceSaveRequest;
 import com.chaerok.backend.course.dto.SelectedCourseResponse;
 import com.chaerok.backend.course.entity.Course;
-import com.chaerok.backend.course.entity.CoursePlace;
 import com.chaerok.backend.course.entity.CourseStatus;
 import com.chaerok.backend.course.repository.CoursePlaceRepository;
 import com.chaerok.backend.course.repository.CourseRepository;
-import com.chaerok.backend.global.exception.PlaceNotFoundException;
 import com.chaerok.backend.global.exception.RegionNotFoundException;
-import com.chaerok.backend.place.entity.Place;
-import com.chaerok.backend.place.entity.PlaceCategoryDetail;
-import com.chaerok.backend.place.entity.PlaceCategoryGroup;
-import com.chaerok.backend.place.entity.PlaceSource;
-import com.chaerok.backend.place.external.TourApiPlaceClient;
-import com.chaerok.backend.place.external.TourApiPlaceItem;
-import com.chaerok.backend.place.repository.PlaceRepository;
-import com.chaerok.backend.place.service.PlaceCategoryMapper;
 import com.chaerok.backend.region.entity.Region;
 import com.chaerok.backend.region.repository.RegionRepository;
 import com.chaerok.backend.user.entity.User;
@@ -27,14 +17,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class CourseCommandService {
 
     private static final int MAX_COURSE_PLACE_COUNT = 3;
@@ -43,8 +29,8 @@ public class CourseCommandService {
     private final CoursePlaceRepository coursePlaceRepository;
     private final UserRepository userRepository;
     private final RegionRepository regionRepository;
-    private final PlaceRepository placeRepository;
-    private final TourApiPlaceClient tourApiPlaceClient;
+    private final CourseExternalPlaceResolver externalPlaceResolver;
+    private final CoursePersistenceService persistenceService;
 
     public SelectedCourseResponse createCourse(
             Long userId,
@@ -55,15 +41,15 @@ public class CourseCommandService {
         User user = findUser(userId);
         Region region = findRegion(request.regionId());
 
-        inactiveActiveCourses(userId);
+        List<ResolvedCoursePlace> resolvedPlaces =
+                resolvePlaces(region, request.places());
 
-        Course course = courseRepository.save(
-                Course.create(user, region, request.title())
+        return persistenceService.createCourse(
+                user,
+                region,
+                request.title(),
+                resolvedPlaces
         );
-
-        addPlaces(course, region, request.places());
-
-        return getCourseResponse(course);
     }
 
     public SelectedCourseResponse addPlacesToActiveCourse(
@@ -75,20 +61,14 @@ public class CourseCommandService {
         Course course = findActiveCourse(userId);
         Region region = course.getRegion();
 
-        int currentPlaceCount = coursePlaceRepository.countByCourseId(
-                course.getId()
+        List<ResolvedCoursePlace> resolvedPlaces =
+                resolvePlaces(region, request.places());
+
+        return persistenceService.addPlacesToCourse(
+                course,
+                region,
+                resolvedPlaces
         );
-
-        if (currentPlaceCount + request.places().size()
-                > MAX_COURSE_PLACE_COUNT) {
-            throw new IllegalArgumentException(
-                    "ACTIVE 코스에는 최대 3개 장소까지만 저장할 수 있습니다."
-            );
-        }
-
-        addPlaces(course, region, request.places());
-
-        return getCourseResponse(course);
     }
 
     @Transactional(readOnly = true)
@@ -97,374 +77,30 @@ public class CourseCommandService {
         return getCourseResponse(course);
     }
 
-    private void inactiveActiveCourses(Long userId) {
-        List<Course> activeCourses = courseRepository
-                .findAllByUserIdAndStatus(userId, CourseStatus.ACTIVE);
-
-        activeCourses.forEach(Course::inactive);
-    }
-
-    private void addPlaces(
-            Course course,
+    private List<ResolvedCoursePlace> resolvePlaces(
             Region region,
             List<CoursePlaceSaveRequest> requests
     ) {
-        validateDuplicateCategoryInRequest(requests);
+        return requests.stream()
+                .map(request -> {
+                    if (request.placeId() != null) {
+                        return ResolvedCoursePlace.of(
+                                request,
+                                null
+                        );
+                    }
 
-        int nextSequence = coursePlaceRepository.countByCourseId(
-                course.getId()
-        ) + 1;
-
-        for (CoursePlaceSaveRequest request : requests) {
-            Place place = resolvePlace(region, request);
-
-            validateCoursePlace(course, place);
-
-            CoursePlace coursePlace = CoursePlace.create(
-                    course,
-                    place,
-                    nextSequence++
-            );
-
-            coursePlaceRepository.save(coursePlace);
-        }
-    }
-
-    private Place resolvePlace(
-            Region region,
-            CoursePlaceSaveRequest request
-    ) {
-        if (request.placeId() != null) {
-            Place place = placeRepository.findById(request.placeId())
-                    .orElseThrow(PlaceNotFoundException::new);
-
-            validatePlaceRegion(region, place);
-
-            return place;
-        }
-
-        return resolveExternalPlace(region, request);
-    }
-
-    private Place resolveExternalPlace(
-            Region region,
-            CoursePlaceSaveRequest request
-    ) {
-        Place tourApiPlace = findOrCreateTourApiPlace(region, request);
-
-        if (tourApiPlace != null) {
-            validatePlaceRegion(region, tourApiPlace);
-            return tourApiPlace;
-        }
-
-        Place kakaoPlace = findOrCreateKakaoPlace(region, request);
-        validatePlaceRegion(region, kakaoPlace);
-
-        return kakaoPlace;
-    }
-
-    private Place findOrCreateTourApiPlace(
-            Region region,
-            CoursePlaceSaveRequest request
-    ) {
-        if (isTourApiRequest(request)
-                && hasText(request.externalPlaceId())) {
-            return placeRepository.findByTourContentId(
-                            request.externalPlaceId()
-                    )
-                    .orElseGet(() -> createTourApiPlaceByContentIdOrThrow(
-                            region,
-                            request.externalPlaceId()
-                    ));
-        }
-
-        List<TourApiPlaceItem> items =
-                tourApiPlaceClient.searchPlacesByKeyword(
-                        request.title(),
-                        region.getLdongRegnCd(),
-                        region.getLdongSignguCd()
-                );
-
-        return items.stream()
-                .filter(item -> isSamePlace(item, request))
-                .findFirst()
-                .map(item -> placeRepository.findByTourContentId(
-                                item.contentId()
-                        )
-                        .orElseGet(() -> createTourApiPlace(region, item)))
-                .orElse(null);
-    }
-
-    private Place createTourApiPlaceByContentIdOrThrow(
-            Region region,
-            String contentId
-    ) {
-        TourApiPlaceItem item = tourApiPlaceClient.getPlaceDetail(contentId);
-
-        if (item == null) {
-            throw new IllegalArgumentException(
-                    "TourAPI 장소 정보를 찾을 수 없습니다."
-            );
-        }
-
-        validateTourApiItemRegion(region, item);
-
-        return createTourApiPlace(region, item);
-    }
-
-    private Place createTourApiPlace(
-            Region region,
-            TourApiPlaceItem item
-    ) {
-        validateTourApiItemRegion(region, item);
-
-        PlaceCategoryGroup categoryGroup = PlaceCategoryMapper.toGroup(
-                item.lclsSystm1(),
-                item.lclsSystm3()
-        );
-
-        PlaceCategoryDetail categoryDetail = PlaceCategoryMapper.toDetail(
-                item.lclsSystm1(),
-                item.lclsSystm3()
-        );
-
-        Place place = Place.create(
-                region,
-                item.contentId(),
-                null,
-                item.title(),
-                item.address(),
-                toBigDecimal(item.latitude()),
-                toBigDecimal(item.longitude()),
-                item.firstImageUrl(),
-                item.lDongRegnCd(),
-                item.lDongSignguCd(),
-                item.lclsSystm1(),
-                item.lclsSystm2(),
-                item.lclsSystm3(),
-                categoryGroup,
-                categoryDetail,
-                false,
-                PlaceSource.TOUR_API
-        );
-
-        return placeRepository.save(place);
-    }
-
-    private void validateTourApiItemRegion(
-            Region region,
-            TourApiPlaceItem item
-    ) {
-        if (!region.getLdongRegnCd().equals(item.lDongRegnCd())
-                || !region.getLdongSignguCd().equals(item.lDongSignguCd())) {
-            throw new IllegalArgumentException(
-                    "TourAPI 장소가 코스 지역과 일치하지 않습니다."
-            );
-        }
-    }
-
-    private Place findOrCreateKakaoPlace(
-            Region region,
-            CoursePlaceSaveRequest request
-    ) {
-        if (!hasText(request.externalPlaceId())) {
-            throw new IllegalArgumentException(
-                    "외부 후보 장소 저장 시 externalPlaceId는 필수입니다."
-            );
-        }
-
-        return placeRepository.findByKakaoPlaceId(request.externalPlaceId())
-                .orElseGet(() -> createKakaoPlace(region, request));
-    }
-
-    private Place createKakaoPlace(
-            Region region,
-            CoursePlaceSaveRequest request
-    ) {
-        validateKakaoPlaceRequest(region, request);
-
-        PlaceCategoryGroup categoryGroup = toCategoryGroup(
-                request.categoryGroup()
-        );
-
-        PlaceCategoryDetail categoryDetail = toCategoryDetail(
-                request.categoryDetail(),
-                categoryGroup
-        );
-
-        Place place = Place.create(
-                region,
-                null,
-                request.externalPlaceId(),
-                request.title(),
-                request.address(),
-                request.latitude(),
-                request.longitude(),
-                null,
-                region.getLdongRegnCd(),
-                region.getLdongSignguCd(),
-                null,
-                null,
-                null,
-                categoryGroup,
-                categoryDetail,
-                false,
-                PlaceSource.KAKAO_LOCAL
-        );
-
-        return placeRepository.save(place);
-    }
-
-    private void validateKakaoPlaceRequest(
-            Region region,
-            CoursePlaceSaveRequest request
-    ) {
-        if (!hasText(request.title())) {
-            throw new IllegalArgumentException(
-                    "Kakao 장소명은 필수입니다."
-            );
-        }
-
-        if (!hasText(request.address())) {
-            throw new IllegalArgumentException(
-                    "Kakao 장소 주소는 필수입니다."
-            );
-        }
-
-        if (request.latitude() == null || request.longitude() == null) {
-            throw new IllegalArgumentException(
-                    "Kakao 장소 좌표는 필수입니다."
-            );
-        }
-
-        if (!isValidLatitude(request.latitude())
-                || !isValidLongitude(request.longitude())) {
-            throw new IllegalArgumentException(
-                    "Kakao 장소 좌표가 올바르지 않습니다."
-            );
-        }
-
-        if (!isAddressInRegion(request.address(), region)) {
-            throw new IllegalArgumentException(
-                    "Kakao 장소가 코스 지역과 일치하지 않습니다."
-            );
-        }
-
-        validateKakaoCategory(request);
-    }
-
-    private boolean isValidLatitude(BigDecimal latitude) {
-        return latitude.compareTo(new BigDecimal("-90")) >= 0
-                && latitude.compareTo(new BigDecimal("90")) <= 0;
-    }
-
-    private boolean isValidLongitude(BigDecimal longitude) {
-        return longitude.compareTo(new BigDecimal("-180")) >= 0
-                && longitude.compareTo(new BigDecimal("180")) <= 0;
-    }
-
-    private boolean isAddressInRegion(
-            String address,
-            Region region
-    ) {
-        if (!hasText(address)
-                || !hasText(region.getCityCountyName())) {
-            return false;
-        }
-
-        return address.contains(region.getCityCountyName());
-    }
-
-    private void validateKakaoCategory(
-            CoursePlaceSaveRequest request
-    ) {
-        PlaceCategoryGroup categoryGroup =
-                toCategoryGroup(request.categoryGroup());
-
-        if (!hasText(request.categoryDetail())) {
-            return;
-        }
-
-        PlaceCategoryDetail categoryDetail;
-
-        try {
-            categoryDetail = PlaceCategoryDetail.valueOf(
-                    request.categoryDetail()
-            );
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException(
-                    "지원하지 않는 장소 세부 유형입니다."
-            );
-        }
-
-        boolean valid = switch (categoryGroup) {
-            case TOURISM ->
-                    categoryDetail == PlaceCategoryDetail.EXPERIENCE
-                            || categoryDetail == PlaceCategoryDetail.HERITAGE
-                            || categoryDetail == PlaceCategoryDetail.NATURE
-                            || categoryDetail == PlaceCategoryDetail.MUSEUM
-                            || categoryDetail == PlaceCategoryDetail.MARKET
-                            || categoryDetail == PlaceCategoryDetail.SOUVENIR_SHOP;
-
-            case FOOD ->
-                    categoryDetail == PlaceCategoryDetail.RESTAURANT
-                            || categoryDetail == PlaceCategoryDetail.LOCAL_FOOD
-                            || categoryDetail == PlaceCategoryDetail.SNACK_MEAL
-                            || categoryDetail == PlaceCategoryDetail.SNACK;
-
-            case CAFE_DESSERT ->
-                    categoryDetail == PlaceCategoryDetail.CAFE
-                            || categoryDetail == PlaceCategoryDetail.DESSERT
-                            || categoryDetail == PlaceCategoryDetail.BAKERY
-                            || categoryDetail == PlaceCategoryDetail.TEA_HOUSE;
-        };
-
-        if (!valid) {
-            throw new IllegalArgumentException(
-                    "장소 유형과 세부 유형이 일치하지 않습니다."
-            );
-        }
-    }
-
-    private void validateCoursePlace(
-            Course course,
-            Place place
-    ) {
-        if (coursePlaceRepository.existsByCourseIdAndPlaceId(
-                course.getId(),
-                place.getId()
-        )) {
-            throw new IllegalArgumentException(
-                    "이미 ACTIVE 코스에 저장된 장소입니다."
-            );
-        }
-
-        if (coursePlaceRepository.existsByCourseIdAndCategoryGroup(
-                course.getId(),
-                place.getCategoryGroup()
-        )) {
-            throw new IllegalArgumentException(
-                    "이미 ACTIVE 코스에 저장된 장소 유형입니다."
-            );
-        }
-    }
-
-    private void validateDuplicateCategoryInRequest(
-            List<CoursePlaceSaveRequest> requests
-    ) {
-        Set<PlaceCategoryGroup> categoryGroups = new HashSet<>();
-
-        for (CoursePlaceSaveRequest request : requests) {
-            PlaceCategoryGroup categoryGroup = toCategoryGroup(
-                    request.categoryGroup()
-            );
-
-            if (!categoryGroups.add(categoryGroup)) {
-                throw new IllegalArgumentException(
-                        "한 번의 요청에 동일한 장소 유형을 중복 저장할 수 없습니다."
-                );
-            }
-        }
+                    return ResolvedCoursePlace.of(
+                            request,
+                            externalPlaceResolver
+                                    .resolveTourApiPlace(
+                                            region,
+                                            request
+                                    )
+                                    .orElse(null)
+                    );
+                })
+                .toList();
     }
 
     private void validatePlaceRequestSize(
@@ -483,29 +119,25 @@ public class CourseCommandService {
         }
     }
 
-    private void validatePlaceRegion(
-            Region region,
-            Place place
+    private SelectedCourseResponse getCourseResponse(
+            Course course
     ) {
-        if (!place.getRegion().getId().equals(region.getId())) {
-            throw new IllegalArgumentException(
-                    "선택한 장소가 코스 지역과 일치하지 않습니다."
-            );
-        }
-    }
-
-    private SelectedCourseResponse getCourseResponse(Course course) {
-        List<CoursePlace> coursePlaces = coursePlaceRepository
-                .findByCourseIdOrderBySequenceAsc(course.getId());
-
-        return SelectedCourseResponse.of(course, coursePlaces);
+        return SelectedCourseResponse.of(
+                course,
+                coursePlaceRepository
+                        .findByCourseIdOrderBySequenceAsc(
+                                course.getId()
+                        )
+        );
     }
 
     private User findUser(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "사용자를 찾을 수 없습니다."
-                ));
+                .orElseThrow(() ->
+                        new IllegalArgumentException(
+                                "사용자를 찾을 수 없습니다."
+                        )
+                );
     }
 
     private Region findRegion(Long regionId) {
@@ -518,94 +150,10 @@ public class CourseCommandService {
                         userId,
                         CourseStatus.ACTIVE
                 )
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "ACTIVE 코스가 없습니다."
-                ));
-    }
-
-    private boolean isTourApiRequest(CoursePlaceSaveRequest request) {
-        return PlaceSource.TOUR_API.name().equals(request.source());
-    }
-
-    private boolean isSamePlace(
-            TourApiPlaceItem item,
-            CoursePlaceSaveRequest request
-    ) {
-        String itemTitle = normalize(item.title());
-        String requestTitle = normalize(request.title());
-
-        if (!itemTitle.equals(requestTitle)) {
-            return false;
-        }
-
-        if (!hasText(request.address())) {
-            return true;
-        }
-
-        String itemAddress = normalize(item.address());
-        String requestAddress = normalize(request.address());
-
-        return itemAddress.contains(requestAddress)
-                || requestAddress.contains(itemAddress);
-    }
-
-    private PlaceCategoryGroup toCategoryGroup(String value) {
-        try {
-            return PlaceCategoryGroup.valueOf(value);
-        } catch (RuntimeException exception) {
-            throw new IllegalArgumentException(
-                    "지원하지 않는 장소 유형입니다."
-            );
-        }
-    }
-
-    private PlaceCategoryDetail toCategoryDetail(
-            String value,
-            PlaceCategoryGroup categoryGroup
-    ) {
-        if (!hasText(value)) {
-            return getDefaultCategoryDetail(categoryGroup);
-        }
-
-        try {
-            return PlaceCategoryDetail.valueOf(value);
-        } catch (RuntimeException exception) {
-            return getDefaultCategoryDetail(categoryGroup);
-        }
-    }
-
-    private PlaceCategoryDetail getDefaultCategoryDetail(
-            PlaceCategoryGroup categoryGroup
-    ) {
-        return switch (categoryGroup) {
-            case TOURISM -> PlaceCategoryDetail.EXPERIENCE;
-            case FOOD -> PlaceCategoryDetail.RESTAURANT;
-            case CAFE_DESSERT -> PlaceCategoryDetail.CAFE;
-        };
-    }
-
-    private BigDecimal toBigDecimal(String value) {
-        if (!hasText(value)) {
-            return null;
-        }
-
-        try {
-            return new BigDecimal(value);
-        } catch (NumberFormatException exception) {
-            return null;
-        }
-    }
-
-    private String normalize(String value) {
-        if (value == null) {
-            return "";
-        }
-
-        return value.replaceAll("\\s+", "")
-                .toLowerCase();
-    }
-
-    private boolean hasText(String value) {
-        return value != null && !value.isBlank();
+                .orElseThrow(() ->
+                        new IllegalArgumentException(
+                                "ACTIVE 코스가 없습니다."
+                        )
+                );
     }
 }

--- a/src/main/java/com/chaerok/backend/course/service/CourseExternalPlaceResolver.java
+++ b/src/main/java/com/chaerok/backend/course/service/CourseExternalPlaceResolver.java
@@ -1,0 +1,109 @@
+package com.chaerok.backend.course.service;
+
+import com.chaerok.backend.course.dto.CoursePlaceSaveRequest;
+import com.chaerok.backend.place.entity.PlaceSource;
+import com.chaerok.backend.place.external.TourApiPlaceClient;
+import com.chaerok.backend.place.external.TourApiPlaceItem;
+import com.chaerok.backend.region.entity.Region;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CourseExternalPlaceResolver {
+
+    private final TourApiPlaceClient tourApiPlaceClient;
+
+    public Optional<TourApiPlaceItem> resolveTourApiPlace(
+            Region region,
+            CoursePlaceSaveRequest request
+    ) {
+        if (request.placeId() != null) {
+            return Optional.empty();
+        }
+
+        if (isTourApiRequest(request)
+                && hasText(request.externalPlaceId())) {
+            TourApiPlaceItem item = tourApiPlaceClient.getPlaceDetail(
+                    request.externalPlaceId()
+            );
+
+            if (item == null) {
+                throw new IllegalArgumentException(
+                        "TourAPI 장소 정보를 찾을 수 없습니다."
+                );
+            }
+
+            validateRegion(region, item);
+
+            return Optional.of(item);
+        }
+
+        List<TourApiPlaceItem> items =
+                tourApiPlaceClient.searchPlacesByKeyword(
+                        request.title(),
+                        region.getLdongRegnCd(),
+                        region.getLdongSignguCd()
+                );
+
+        return items.stream()
+                .filter(item -> isSamePlace(item, request))
+                .findFirst();
+    }
+
+    private void validateRegion(
+            Region region,
+            TourApiPlaceItem item
+    ) {
+        if (!region.getLdongRegnCd().equals(item.lDongRegnCd())
+                || !region.getLdongSignguCd().equals(item.lDongSignguCd())) {
+            throw new IllegalArgumentException(
+                    "TourAPI 장소가 코스 지역과 일치하지 않습니다."
+            );
+        }
+    }
+
+    private boolean isTourApiRequest(
+            CoursePlaceSaveRequest request
+    ) {
+        return PlaceSource.TOUR_API.name().equals(request.source());
+    }
+
+    private boolean isSamePlace(
+            TourApiPlaceItem item,
+            CoursePlaceSaveRequest request
+    ) {
+        String itemTitle = normalize(item.title());
+        String requestTitle = normalize(request.title());
+
+        if (!itemTitle.equals(requestTitle)) {
+            return false;
+        }
+
+        if (!hasText(request.address())) {
+            return true;
+        }
+
+        String itemAddress = normalize(item.address());
+        String requestAddress = normalize(request.address());
+
+        return itemAddress.contains(requestAddress)
+                || requestAddress.contains(itemAddress);
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value.replaceAll("\\s+", "")
+                .toLowerCase();
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/src/main/java/com/chaerok/backend/course/service/CoursePersistenceService.java
+++ b/src/main/java/com/chaerok/backend/course/service/CoursePersistenceService.java
@@ -1,0 +1,496 @@
+package com.chaerok.backend.course.service;
+
+import com.chaerok.backend.course.dto.CoursePlaceSaveRequest;
+import com.chaerok.backend.course.dto.SelectedCourseResponse;
+import com.chaerok.backend.course.entity.Course;
+import com.chaerok.backend.course.entity.CoursePlace;
+import com.chaerok.backend.course.entity.CourseStatus;
+import com.chaerok.backend.course.repository.CoursePlaceRepository;
+import com.chaerok.backend.course.repository.CourseRepository;
+import com.chaerok.backend.global.exception.PlaceNotFoundException;
+import com.chaerok.backend.place.entity.Place;
+import com.chaerok.backend.place.entity.PlaceCategoryDetail;
+import com.chaerok.backend.place.entity.PlaceCategoryGroup;
+import com.chaerok.backend.place.entity.PlaceSource;
+import com.chaerok.backend.place.external.TourApiPlaceItem;
+import com.chaerok.backend.place.repository.PlaceRepository;
+import com.chaerok.backend.place.service.PlaceCategoryMapper;
+import com.chaerok.backend.region.entity.Region;
+import com.chaerok.backend.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class CoursePersistenceService {
+
+    private static final int MAX_COURSE_PLACE_COUNT = 3;
+
+    private final CourseRepository courseRepository;
+    private final CoursePlaceRepository coursePlaceRepository;
+    private final PlaceRepository placeRepository;
+
+    @Transactional
+    public SelectedCourseResponse createCourse(
+            User user,
+            Region region,
+            String title,
+            List<ResolvedCoursePlace> resolvedPlaces
+    ) {
+        inactiveActiveCourses(user.getId());
+
+        Course course = courseRepository.save(
+                Course.create(user, region, title)
+        );
+
+        addPlaces(course, region, resolvedPlaces);
+
+        return getCourseResponse(course);
+    }
+
+    @Transactional
+    public SelectedCourseResponse addPlacesToCourse(
+            Course course,
+            Region region,
+            List<ResolvedCoursePlace> resolvedPlaces
+    ) {
+        int currentPlaceCount = coursePlaceRepository.countByCourseId(
+                course.getId()
+        );
+
+        if (currentPlaceCount + resolvedPlaces.size()
+                > MAX_COURSE_PLACE_COUNT) {
+            throw new IllegalArgumentException(
+                    "ACTIVE 코스에는 최대 3개 장소까지만 저장할 수 있습니다."
+            );
+        }
+
+        addPlaces(course, region, resolvedPlaces);
+
+        return getCourseResponse(course);
+    }
+
+    private void inactiveActiveCourses(Long userId) {
+        List<Course> activeCourses = courseRepository
+                .findAllByUserIdAndStatus(
+                        userId,
+                        CourseStatus.ACTIVE
+                );
+
+        activeCourses.forEach(Course::inactive);
+    }
+
+    private void addPlaces(
+            Course course,
+            Region region,
+            List<ResolvedCoursePlace> resolvedPlaces
+    ) {
+        validateDuplicateCategoryInRequest(resolvedPlaces);
+
+        int nextSequence = coursePlaceRepository.countByCourseId(
+                course.getId()
+        ) + 1;
+
+        for (ResolvedCoursePlace resolvedPlace : resolvedPlaces) {
+            Place place = resolvePlace(region, resolvedPlace);
+
+            validateCoursePlace(course, place);
+
+            CoursePlace coursePlace = CoursePlace.create(
+                    course,
+                    place,
+                    nextSequence++
+            );
+
+            coursePlaceRepository.save(coursePlace);
+        }
+    }
+
+    private Place resolvePlace(
+            Region region,
+            ResolvedCoursePlace resolvedPlace
+    ) {
+        CoursePlaceSaveRequest request = resolvedPlace.request();
+
+        if (request.placeId() != null) {
+            Place place = placeRepository.findById(request.placeId())
+                    .orElseThrow(PlaceNotFoundException::new);
+
+            validatePlaceRegion(region, place);
+
+            return place;
+        }
+
+        if (resolvedPlace.hasTourApiPlace()) {
+            Place place = findOrCreateTourApiPlace(
+                    region,
+                    resolvedPlace.tourApiPlace()
+            );
+
+            validatePlaceRegion(region, place);
+
+            return place;
+        }
+
+        Place place = findOrCreateKakaoPlace(region, request);
+        validatePlaceRegion(region, place);
+
+        return place;
+    }
+
+    private Place findOrCreateTourApiPlace(
+            Region region,
+            TourApiPlaceItem item
+    ) {
+        return placeRepository.findByTourContentId(item.contentId())
+                .orElseGet(() -> createTourApiPlace(region, item));
+    }
+
+    private Place createTourApiPlace(
+            Region region,
+            TourApiPlaceItem item
+    ) {
+        validateTourApiItemRegion(region, item);
+
+        PlaceCategoryGroup categoryGroup =
+                PlaceCategoryMapper.toGroup(
+                        item.lclsSystm1(),
+                        item.lclsSystm3()
+                );
+
+        PlaceCategoryDetail categoryDetail =
+                PlaceCategoryMapper.toDetail(
+                        item.lclsSystm1(),
+                        item.lclsSystm3()
+                );
+
+        Place place = Place.create(
+                region,
+                item.contentId(),
+                null,
+                item.title(),
+                item.address(),
+                toBigDecimal(item.latitude()),
+                toBigDecimal(item.longitude()),
+                item.firstImageUrl(),
+                item.lDongRegnCd(),
+                item.lDongSignguCd(),
+                item.lclsSystm1(),
+                item.lclsSystm2(),
+                item.lclsSystm3(),
+                categoryGroup,
+                categoryDetail,
+                false,
+                PlaceSource.TOUR_API
+        );
+
+        return placeRepository.save(place);
+    }
+
+    private void validateTourApiItemRegion(
+            Region region,
+            TourApiPlaceItem item
+    ) {
+        if (!region.getLdongRegnCd().equals(item.lDongRegnCd())
+                || !region.getLdongSignguCd().equals(item.lDongSignguCd())) {
+            throw new IllegalArgumentException(
+                    "TourAPI 장소가 코스 지역과 일치하지 않습니다."
+            );
+        }
+    }
+
+    private Place findOrCreateKakaoPlace(
+            Region region,
+            CoursePlaceSaveRequest request
+    ) {
+        if (!hasText(request.externalPlaceId())) {
+            throw new IllegalArgumentException(
+                    "외부 후보 장소 저장 시 externalPlaceId는 필수입니다."
+            );
+        }
+
+        return placeRepository.findByKakaoPlaceId(
+                        request.externalPlaceId()
+                )
+                .orElseGet(() ->
+                        createKakaoPlace(region, request)
+                );
+    }
+
+    private Place createKakaoPlace(
+            Region region,
+            CoursePlaceSaveRequest request
+    ) {
+        validateKakaoPlaceRequest(region, request);
+
+        PlaceCategoryGroup categoryGroup =
+                toCategoryGroup(request.categoryGroup());
+
+        PlaceCategoryDetail categoryDetail =
+                toCategoryDetail(
+                        request.categoryDetail(),
+                        categoryGroup
+                );
+
+        Place place = Place.create(
+                region,
+                null,
+                request.externalPlaceId(),
+                request.title(),
+                request.address(),
+                request.latitude(),
+                request.longitude(),
+                null,
+                region.getLdongRegnCd(),
+                region.getLdongSignguCd(),
+                null,
+                null,
+                null,
+                categoryGroup,
+                categoryDetail,
+                false,
+                PlaceSource.KAKAO_LOCAL
+        );
+
+        return placeRepository.save(place);
+    }
+
+    private void validateKakaoPlaceRequest(
+            Region region,
+            CoursePlaceSaveRequest request
+    ) {
+        if (!hasText(request.title())) {
+            throw new IllegalArgumentException(
+                    "Kakao 장소명은 필수입니다."
+            );
+        }
+
+        if (!hasText(request.address())) {
+            throw new IllegalArgumentException(
+                    "Kakao 장소 주소는 필수입니다."
+            );
+        }
+
+        if (request.latitude() == null
+                || request.longitude() == null) {
+            throw new IllegalArgumentException(
+                    "Kakao 장소 좌표는 필수입니다."
+            );
+        }
+
+        if (!isValidLatitude(request.latitude())
+                || !isValidLongitude(request.longitude())) {
+            throw new IllegalArgumentException(
+                    "Kakao 장소 좌표가 올바르지 않습니다."
+            );
+        }
+
+        if (!isAddressInRegion(request.address(), region)) {
+            throw new IllegalArgumentException(
+                    "Kakao 장소가 코스 지역과 일치하지 않습니다."
+            );
+        }
+
+        validateKakaoCategory(request);
+    }
+
+    private boolean isValidLatitude(BigDecimal latitude) {
+        return latitude.compareTo(new BigDecimal("-90")) >= 0
+                && latitude.compareTo(new BigDecimal("90")) <= 0;
+    }
+
+    private boolean isValidLongitude(BigDecimal longitude) {
+        return longitude.compareTo(new BigDecimal("-180")) >= 0
+                && longitude.compareTo(new BigDecimal("180")) <= 0;
+    }
+
+    private boolean isAddressInRegion(
+            String address,
+            Region region
+    ) {
+        if (!hasText(address)
+                || !hasText(region.getCityCountyName())) {
+            return false;
+        }
+
+        return address.contains(region.getCityCountyName());
+    }
+
+    private void validateKakaoCategory(
+            CoursePlaceSaveRequest request
+    ) {
+        PlaceCategoryGroup categoryGroup =
+                toCategoryGroup(request.categoryGroup());
+
+        if (!hasText(request.categoryDetail())) {
+            return;
+        }
+
+        PlaceCategoryDetail categoryDetail;
+
+        try {
+            categoryDetail = PlaceCategoryDetail.valueOf(
+                    request.categoryDetail()
+            );
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "지원하지 않는 장소 세부 유형입니다."
+            );
+        }
+
+        boolean valid = switch (categoryGroup) {
+            case TOURISM ->
+                    categoryDetail == PlaceCategoryDetail.EXPERIENCE
+                            || categoryDetail == PlaceCategoryDetail.HERITAGE
+                            || categoryDetail == PlaceCategoryDetail.NATURE
+                            || categoryDetail == PlaceCategoryDetail.MUSEUM
+                            || categoryDetail == PlaceCategoryDetail.MARKET
+                            || categoryDetail == PlaceCategoryDetail.SOUVENIR_SHOP;
+
+            case FOOD ->
+                    categoryDetail == PlaceCategoryDetail.RESTAURANT
+                            || categoryDetail == PlaceCategoryDetail.LOCAL_FOOD
+                            || categoryDetail == PlaceCategoryDetail.SNACK_MEAL
+                            || categoryDetail == PlaceCategoryDetail.SNACK;
+
+            case CAFE_DESSERT ->
+                    categoryDetail == PlaceCategoryDetail.CAFE
+                            || categoryDetail == PlaceCategoryDetail.DESSERT
+                            || categoryDetail == PlaceCategoryDetail.BAKERY
+                            || categoryDetail == PlaceCategoryDetail.TEA_HOUSE;
+        };
+
+        if (!valid) {
+            throw new IllegalArgumentException(
+                    "장소 유형과 세부 유형이 일치하지 않습니다."
+            );
+        }
+    }
+
+    private void validateCoursePlace(
+            Course course,
+            Place place
+    ) {
+        if (coursePlaceRepository.existsByCourseIdAndPlaceId(
+                course.getId(),
+                place.getId()
+        )) {
+            throw new IllegalArgumentException(
+                    "이미 ACTIVE 코스에 저장된 장소입니다."
+            );
+        }
+
+        if (coursePlaceRepository
+                .existsByCourseIdAndCategoryGroup(
+                        course.getId(),
+                        place.getCategoryGroup()
+                )) {
+            throw new IllegalArgumentException(
+                    "이미 ACTIVE 코스에 저장된 장소 유형입니다."
+            );
+        }
+    }
+
+    private void validateDuplicateCategoryInRequest(
+            List<ResolvedCoursePlace> resolvedPlaces
+    ) {
+        Set<PlaceCategoryGroup> categoryGroups = new HashSet<>();
+
+        for (ResolvedCoursePlace resolvedPlace : resolvedPlaces) {
+            CoursePlaceSaveRequest request =
+                    resolvedPlace.request();
+
+            PlaceCategoryGroup categoryGroup =
+                    toCategoryGroup(request.categoryGroup());
+
+            if (!categoryGroups.add(categoryGroup)) {
+                throw new IllegalArgumentException(
+                        "한 번의 요청에 동일한 장소 유형을 중복 저장할 수 없습니다."
+                );
+            }
+        }
+    }
+
+    private void validatePlaceRegion(
+            Region region,
+            Place place
+    ) {
+        if (!place.getRegion().getId().equals(region.getId())) {
+            throw new IllegalArgumentException(
+                    "선택한 장소가 코스 지역과 일치하지 않습니다."
+            );
+        }
+    }
+
+    private SelectedCourseResponse getCourseResponse(
+            Course course
+    ) {
+        List<CoursePlace> coursePlaces =
+                coursePlaceRepository
+                        .findByCourseIdOrderBySequenceAsc(
+                                course.getId()
+                        );
+
+        return SelectedCourseResponse.of(
+                course,
+                coursePlaces
+        );
+    }
+
+    private PlaceCategoryGroup toCategoryGroup(String value) {
+        try {
+            return PlaceCategoryGroup.valueOf(value);
+        } catch (RuntimeException exception) {
+            throw new IllegalArgumentException(
+                    "지원하지 않는 장소 유형입니다."
+            );
+        }
+    }
+
+    private PlaceCategoryDetail toCategoryDetail(
+            String value,
+            PlaceCategoryGroup categoryGroup
+    ) {
+        if (!hasText(value)) {
+            return getDefaultCategoryDetail(categoryGroup);
+        }
+
+        try {
+            return PlaceCategoryDetail.valueOf(value);
+        } catch (RuntimeException exception) {
+            return getDefaultCategoryDetail(categoryGroup);
+        }
+    }
+
+    private PlaceCategoryDetail getDefaultCategoryDetail(
+            PlaceCategoryGroup categoryGroup
+    ) {
+        return switch (categoryGroup) {
+            case TOURISM -> PlaceCategoryDetail.EXPERIENCE;
+            case FOOD -> PlaceCategoryDetail.RESTAURANT;
+            case CAFE_DESSERT -> PlaceCategoryDetail.CAFE;
+        };
+    }
+
+    private BigDecimal toBigDecimal(String value) {
+        if (!hasText(value)) {
+            return null;
+        }
+
+        try {
+            return new BigDecimal(value);
+        } catch (NumberFormatException exception) {
+            return null;
+        }
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/src/main/java/com/chaerok/backend/course/service/CourseRecommendService.java
+++ b/src/main/java/com/chaerok/backend/course/service/CourseRecommendService.java
@@ -14,7 +14,6 @@ import com.chaerok.backend.place.repository.PlaceRepository;
 import com.chaerok.backend.region.repository.RegionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
@@ -24,7 +23,6 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class CourseRecommendService {
 
     private static final String RECOMMENDATION_TYPE_REGION = "REGION";

--- a/src/main/java/com/chaerok/backend/course/service/ResolvedCoursePlace.java
+++ b/src/main/java/com/chaerok/backend/course/service/ResolvedCoursePlace.java
@@ -1,0 +1,24 @@
+package com.chaerok.backend.course.service;
+
+import com.chaerok.backend.course.dto.CoursePlaceSaveRequest;
+import com.chaerok.backend.place.external.TourApiPlaceItem;
+
+public record ResolvedCoursePlace(
+        CoursePlaceSaveRequest request,
+        TourApiPlaceItem tourApiPlace
+) {
+
+    public static ResolvedCoursePlace of(
+            CoursePlaceSaveRequest request,
+            TourApiPlaceItem tourApiPlace
+    ) {
+        return new ResolvedCoursePlace(
+                request,
+                tourApiPlace
+        );
+    }
+
+    public boolean hasTourApiPlace() {
+        return tourApiPlace != null;
+    }
+}

--- a/src/test/java/com/chaerok/backend/course/service/CourseCommandServiceTest.java
+++ b/src/test/java/com/chaerok/backend/course/service/CourseCommandServiceTest.java
@@ -1,17 +1,14 @@
 package com.chaerok.backend.course.service;
 
+import com.chaerok.backend.course.dto.CourseAddPlacesRequest;
 import com.chaerok.backend.course.dto.CourseCreateRequest;
 import com.chaerok.backend.course.dto.CoursePlaceSaveRequest;
+import com.chaerok.backend.course.dto.SelectedCourseResponse;
 import com.chaerok.backend.course.entity.Course;
 import com.chaerok.backend.course.entity.CourseStatus;
 import com.chaerok.backend.course.repository.CoursePlaceRepository;
 import com.chaerok.backend.course.repository.CourseRepository;
-import com.chaerok.backend.place.entity.Place;
-import com.chaerok.backend.place.entity.PlaceCategoryDetail;
-import com.chaerok.backend.place.entity.PlaceCategoryGroup;
-import com.chaerok.backend.place.entity.PlaceSource;
-import com.chaerok.backend.place.external.TourApiPlaceClient;
-import com.chaerok.backend.place.repository.PlaceRepository;
+import com.chaerok.backend.place.external.TourApiPlaceItem;
 import com.chaerok.backend.region.entity.Region;
 import com.chaerok.backend.region.repository.RegionRepository;
 import com.chaerok.backend.user.entity.User;
@@ -29,8 +26,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -51,16 +48,22 @@ class CourseCommandServiceTest {
     private RegionRepository regionRepository;
 
     @Mock
-    private PlaceRepository placeRepository;
+    private CourseExternalPlaceResolver externalPlaceResolver;
 
     @Mock
-    private TourApiPlaceClient tourApiPlaceClient;
+    private CoursePersistenceService persistenceService;
 
     @Mock
     private User user;
 
     @Mock
     private Region region;
+
+    @Mock
+    private Course course;
+
+    @Mock
+    private SelectedCourseResponse response;
 
     private CourseCommandService courseCommandService;
 
@@ -71,371 +74,297 @@ class CourseCommandServiceTest {
                 coursePlaceRepository,
                 userRepository,
                 regionRepository,
-                placeRepository,
-                tourApiPlaceClient
+                externalPlaceResolver,
+                persistenceService
         );
     }
 
     @Test
-    @DisplayName("유효한 Kakao 외부 장소는 신규 Place로 저장한다")
-    void createCourseSavesValidKakaoPlace() {
+    @DisplayName("코스 생성 시 외부 장소를 먼저 조회한 뒤 저장 서비스에 위임한다")
+    void createCourseResolvesExternalPlaceBeforePersistence() {
         // given
-        CoursePlaceSaveRequest placeRequest =
-                createKakaoRequest(
-                        "kakao-1",
-                        "공주 카페",
-                        "CAFE_DESSERT",
-                        "CAFE",
-                        "충남 공주시 웅진로 10",
-                        new BigDecimal("36.4500"),
-                        new BigDecimal("127.1200")
-                );
+        CoursePlaceSaveRequest placeRequest = createTourApiRequest();
 
-        CourseCreateRequest request =
-                new CourseCreateRequest(
-                        1L,
-                        "공주 여행",
-                        List.of(placeRequest)
-                );
-
-        mockCourseCreationBase(placeRequest);
-
-        when(region.getId()).thenReturn(1L);
-        when(region.getCityCountyName()).thenReturn("공주시");
-
-        when(placeRepository.findByKakaoPlaceId("kakao-1"))
-                .thenReturn(Optional.empty());
-
-        when(placeRepository.save(any(Place.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
-
-        // when
-        courseCommandService.createCourse(1L, request);
-
-        // then
-        ArgumentCaptor<Place> placeCaptor =
-                ArgumentCaptor.forClass(Place.class);
-
-        verify(placeRepository).save(placeCaptor.capture());
-
-        Place savedPlace = placeCaptor.getValue();
-
-        assertThat(savedPlace.getKakaoPlaceId())
-                .isEqualTo("kakao-1");
-        assertThat(savedPlace.getTitle())
-                .isEqualTo("공주 카페");
-        assertThat(savedPlace.getAddress())
-                .isEqualTo("충남 공주시 웅진로 10");
-        assertThat(savedPlace.getCategoryGroup())
-                .isEqualTo(PlaceCategoryGroup.CAFE_DESSERT);
-        assertThat(savedPlace.getCategoryDetail())
-                .isEqualTo(PlaceCategoryDetail.CAFE);
-        assertThat(savedPlace.getSource())
-                .isEqualTo(PlaceSource.KAKAO_LOCAL);
-    }
-
-    @Test
-    @DisplayName("다른 시군의 Kakao 외부 장소는 저장하지 않는다")
-    void createCourseRejectsKakaoPlaceOutsideRegion() {
-        // given
-        CoursePlaceSaveRequest placeRequest =
-                createKakaoRequest(
-                        "kakao-2",
-                        "논산 카페",
-                        "CAFE_DESSERT",
-                        "CAFE",
-                        "충남 논산시 시민로 10",
-                        new BigDecimal("36.2000"),
-                        new BigDecimal("127.0000")
-                );
-
-        CourseCreateRequest request =
-                new CourseCreateRequest(
-                        1L,
-                        "공주 여행",
-                        List.of(placeRequest)
-                );
-
-        mockCourseCreationBase(placeRequest);
-        when(region.getCityCountyName()).thenReturn("공주시");
-
-        when(placeRepository.findByKakaoPlaceId("kakao-2"))
-                .thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() ->
-                courseCommandService.createCourse(1L, request)
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Kakao 장소가 코스 지역과 일치하지 않습니다.");
-
-        verify(placeRepository, never())
-                .save(any(Place.class));
-    }
-
-    @Test
-    @DisplayName("좌표가 없는 Kakao 외부 장소는 저장하지 않는다")
-    void createCourseRejectsKakaoPlaceWithoutCoordinates() {
-        // given
-        CoursePlaceSaveRequest placeRequest =
-                createKakaoRequest(
-                        "kakao-3",
-                        "공주 카페",
-                        "CAFE_DESSERT",
-                        "CAFE",
-                        "충남 공주시 웅진로 10",
-                        null,
-                        null
-                );
-
-        CourseCreateRequest request =
-                new CourseCreateRequest(
-                        1L,
-                        "공주 여행",
-                        List.of(placeRequest)
-                );
-
-        mockCourseCreationBase(placeRequest);
-
-        when(placeRepository.findByKakaoPlaceId("kakao-3"))
-                .thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() ->
-                courseCommandService.createCourse(1L, request)
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Kakao 장소 좌표는 필수입니다.");
-
-        verify(placeRepository, never())
-                .save(any(Place.class));
-    }
-
-    @Test
-    @DisplayName("유효 범위를 벗어난 Kakao 외부 장소 좌표는 저장하지 않는다")
-    void createCourseRejectsKakaoPlaceWithInvalidCoordinates() {
-        // given
-        CoursePlaceSaveRequest placeRequest =
-                createKakaoRequest(
-                        "kakao-4",
-                        "공주 카페",
-                        "CAFE_DESSERT",
-                        "CAFE",
-                        "충남 공주시 웅진로 10",
-                        new BigDecimal("91.0000"),
-                        new BigDecimal("127.1200")
-                );
-
-        CourseCreateRequest request =
-                new CourseCreateRequest(
-                        1L,
-                        "공주 여행",
-                        List.of(placeRequest)
-                );
-
-        mockCourseCreationBase(placeRequest);
-
-        when(placeRepository.findByKakaoPlaceId("kakao-4"))
-                .thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() ->
-                courseCommandService.createCourse(1L, request)
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Kakao 장소 좌표가 올바르지 않습니다.");
-
-        verify(placeRepository, never())
-                .save(any(Place.class));
-    }
-
-    @Test
-    @DisplayName("지원하지 않는 Kakao 장소 세부 유형은 저장하지 않는다")
-    void createCourseRejectsUnsupportedKakaoCategoryDetail() {
-        // given
-        CoursePlaceSaveRequest placeRequest =
-                createKakaoRequest(
-                        "kakao-5",
-                        "공주 카페",
-                        "CAFE_DESSERT",
-                        "UNKNOWN",
-                        "충남 공주시 웅진로 10",
-                        new BigDecimal("36.4500"),
-                        new BigDecimal("127.1200")
-                );
-
-        CourseCreateRequest request =
-                new CourseCreateRequest(
-                        1L,
-                        "공주 여행",
-                        List.of(placeRequest)
-                );
-
-        mockCourseCreationBase(placeRequest);
-        when(region.getCityCountyName()).thenReturn("공주시");
-
-        when(placeRepository.findByKakaoPlaceId("kakao-5"))
-                .thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() ->
-                courseCommandService.createCourse(1L, request)
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("지원하지 않는 장소 세부 유형입니다.");
-
-        verify(placeRepository, never())
-                .save(any(Place.class));
-    }
-
-    @Test
-    @DisplayName("장소 유형과 세부 유형이 일치하지 않으면 Kakao 장소를 저장하지 않는다")
-    void createCourseRejectsMismatchedKakaoCategory() {
-        // given
-        CoursePlaceSaveRequest placeRequest =
-                createKakaoRequest(
-                        "kakao-6",
-                        "공주 카페",
-                        "FOOD",
-                        "CAFE",
-                        "충남 공주시 웅진로 10",
-                        new BigDecimal("36.4500"),
-                        new BigDecimal("127.1200")
-                );
-
-        CourseCreateRequest request =
-                new CourseCreateRequest(
-                        1L,
-                        "공주 여행",
-                        List.of(placeRequest)
-                );
-
-        mockCourseCreationBase(placeRequest);
-        when(region.getCityCountyName()).thenReturn("공주시");
-
-        when(placeRepository.findByKakaoPlaceId("kakao-6"))
-                .thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() ->
-                courseCommandService.createCourse(1L, request)
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("장소 유형과 세부 유형이 일치하지 않습니다.");
-
-        verify(placeRepository, never())
-                .save(any(Place.class));
-    }
-
-    @Test
-    @DisplayName("이미 저장된 kakaoPlaceId가 있으면 기존 Place를 재사용한다")
-    void createCourseReusesExistingKakaoPlace() {
-        // given
-        CoursePlaceSaveRequest placeRequest =
-                createKakaoRequest(
-                        "kakao-7",
-                        "공주 카페",
-                        "CAFE_DESSERT",
-                        "CAFE",
-                        "충남 공주시 웅진로 10",
-                        new BigDecimal("36.4500"),
-                        new BigDecimal("127.1200")
-                );
-
-        CourseCreateRequest request =
-                new CourseCreateRequest(
-                        1L,
-                        "공주 여행",
-                        List.of(placeRequest)
-                );
-
-        mockCourseCreationBase(placeRequest);
-
-        when(region.getId()).thenReturn(1L);
-
-        Place existingPlace = Place.create(
-                region,
-                null,
-                "kakao-7",
-                "기존 공주 카페",
-                "충남 공주시 웅진로 10",
-                new BigDecimal("36.4500"),
-                new BigDecimal("127.1200"),
-                null,
-                "44",
-                "150",
-                null,
-                null,
-                null,
-                PlaceCategoryGroup.CAFE_DESSERT,
-                PlaceCategoryDetail.CAFE,
-                false,
-                PlaceSource.KAKAO_LOCAL
+        CourseCreateRequest request = new CourseCreateRequest(
+                1L,
+                "공주 여행",
+                List.of(placeRequest)
         );
 
-        when(placeRepository.findByKakaoPlaceId("kakao-7"))
-                .thenReturn(Optional.of(existingPlace));
+        TourApiPlaceItem tourApiPlace = createTourApiPlaceItem();
 
-        // when
-        courseCommandService.createCourse(1L, request);
-
-        // then
-        verify(placeRepository, never())
-                .save(any(Place.class));
-
-        verify(coursePlaceRepository)
-                .save(any());
-    }
-
-    private void mockCourseCreationBase(
-            CoursePlaceSaveRequest placeRequest
-    ) {
         when(userRepository.findById(1L))
                 .thenReturn(Optional.of(user));
 
         when(regionRepository.findById(1L))
                 .thenReturn(Optional.of(region));
 
-        when(region.getLdongRegnCd()).thenReturn("44");
-        when(region.getLdongSignguCd()).thenReturn("150");
+        when(externalPlaceResolver.resolveTourApiPlace(
+                region,
+                placeRequest
+        )).thenReturn(Optional.of(tourApiPlace));
 
-        when(courseRepository.findAllByUserIdAndStatus(
-                1L,
-                CourseStatus.ACTIVE
-        )).thenReturn(List.of());
+        when(persistenceService.createCourse(
+                any(User.class),
+                any(Region.class),
+                any(String.class),
+                any()
+        )).thenReturn(response);
 
-        when(courseRepository.save(any(Course.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        // when
+        SelectedCourseResponse result =
+                courseCommandService.createCourse(1L, request);
 
-        when(coursePlaceRepository.countByCourseId(null))
-                .thenReturn(0);
+        // then
+        ArgumentCaptor<List<ResolvedCoursePlace>> captor =
+                ArgumentCaptor.forClass(List.class);
 
-        when(tourApiPlaceClient.searchPlacesByKeyword(
-                placeRequest.title(),
-                "44",
-                "150"
-        )).thenReturn(List.of());
+        verify(externalPlaceResolver)
+                .resolveTourApiPlace(region, placeRequest);
+
+        verify(persistenceService)
+                .createCourse(
+                        eq(user),
+                        eq(region),
+                        eq("공주 여행"),
+                        captor.capture()
+                );
+
+        List<ResolvedCoursePlace> resolvedPlaces =
+                captor.getValue();
+
+        assertThat(resolvedPlaces).hasSize(1);
+        assertThat(resolvedPlaces.get(0).request())
+                .isEqualTo(placeRequest);
+        assertThat(resolvedPlaces.get(0).tourApiPlace())
+                .isEqualTo(tourApiPlace);
+
+        assertThat(result).isSameAs(response);
     }
 
-    private CoursePlaceSaveRequest createKakaoRequest(
-            String externalPlaceId,
-            String title,
-            String categoryGroup,
-            String categoryDetail,
-            String address,
-            BigDecimal latitude,
-            BigDecimal longitude
-    ) {
+    @Test
+    @DisplayName("DB 장소 요청은 외부 API 조회 없이 저장 서비스에 전달한다")
+    void createCourseDoesNotResolveExistingDbPlaceExternally() {
+        // given
+        CoursePlaceSaveRequest placeRequest =
+                createDbPlaceRequest();
+
+        CourseCreateRequest request = new CourseCreateRequest(
+                1L,
+                "공주 여행",
+                List.of(placeRequest)
+        );
+
+        when(userRepository.findById(1L))
+                .thenReturn(Optional.of(user));
+
+        when(regionRepository.findById(1L))
+                .thenReturn(Optional.of(region));
+
+        when(persistenceService.createCourse(
+                any(User.class),
+                any(Region.class),
+                any(String.class),
+                any()
+        )).thenReturn(response);
+
+        // when
+        courseCommandService.createCourse(1L, request);
+
+        // then
+        ArgumentCaptor<List<ResolvedCoursePlace>> captor =
+                ArgumentCaptor.forClass(List.class);
+
+        verify(externalPlaceResolver, never())
+                .resolveTourApiPlace(any(), any());
+
+        verify(persistenceService)
+                .createCourse(
+                        eq(user),
+                        eq(region),
+                        eq("공주 여행"),
+                        captor.capture()
+                );
+
+        ResolvedCoursePlace resolvedPlace =
+                captor.getValue().get(0);
+
+        assertThat(resolvedPlace.request())
+                .isEqualTo(placeRequest);
+        assertThat(resolvedPlace.tourApiPlace())
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("TourAPI에서 매칭되지 않은 외부 장소는 Kakao 저장 대상으로 전달한다")
+    void createCoursePassesUnresolvedExternalPlaceToPersistence() {
+        // given
+        CoursePlaceSaveRequest placeRequest =
+                createKakaoRequest();
+
+        CourseCreateRequest request = new CourseCreateRequest(
+                1L,
+                "공주 여행",
+                List.of(placeRequest)
+        );
+
+        when(userRepository.findById(1L))
+                .thenReturn(Optional.of(user));
+
+        when(regionRepository.findById(1L))
+                .thenReturn(Optional.of(region));
+
+        when(externalPlaceResolver.resolveTourApiPlace(
+                region,
+                placeRequest
+        )).thenReturn(Optional.empty());
+
+        when(persistenceService.createCourse(
+                any(User.class),
+                any(Region.class),
+                any(String.class),
+                any()
+        )).thenReturn(response);
+
+        // when
+        courseCommandService.createCourse(1L, request);
+
+        // then
+        ArgumentCaptor<List<ResolvedCoursePlace>> captor =
+                ArgumentCaptor.forClass(List.class);
+
+        verify(persistenceService)
+                .createCourse(
+                        eq(user),
+                        eq(region),
+                        eq("공주 여행"),
+                        captor.capture()
+                );
+
+        ResolvedCoursePlace resolvedPlace =
+                captor.getValue().get(0);
+
+        assertThat(resolvedPlace.request())
+                .isEqualTo(placeRequest);
+        assertThat(resolvedPlace.tourApiPlace())
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("ACTIVE 코스 장소 추가 시 외부 장소 조회 후 저장 서비스에 위임한다")
+    void addPlacesResolvesExternalPlaceBeforePersistence() {
+        // given
+        CoursePlaceSaveRequest placeRequest =
+                createKakaoRequest();
+
+        CourseAddPlacesRequest request =
+                new CourseAddPlacesRequest(
+                        List.of(placeRequest)
+                );
+
+        when(courseRepository.findByUserIdAndStatus(
+                1L,
+                CourseStatus.ACTIVE
+        )).thenReturn(Optional.of(course));
+
+        when(course.getRegion())
+                .thenReturn(region);
+
+        when(externalPlaceResolver.resolveTourApiPlace(
+                region,
+                placeRequest
+        )).thenReturn(Optional.empty());
+
+        when(persistenceService.addPlacesToCourse(
+                any(Course.class),
+                any(Region.class),
+                any()
+        )).thenReturn(response);
+
+        // when
+        SelectedCourseResponse result =
+                courseCommandService.addPlacesToActiveCourse(
+                        1L,
+                        request
+                );
+
+        // then
+        verify(externalPlaceResolver)
+                .resolveTourApiPlace(region, placeRequest);
+
+        verify(persistenceService)
+                .addPlacesToCourse(
+                        course,
+                        region,
+                        List.of(
+                                ResolvedCoursePlace.of(
+                                        placeRequest,
+                                        null
+                                )
+                        )
+                );
+
+        assertThat(result).isSameAs(response);
+    }
+
+    private CoursePlaceSaveRequest createTourApiRequest() {
         return new CoursePlaceSaveRequest(
                 null,
-                externalPlaceId,
-                PlaceSource.KAKAO_LOCAL.name(),
-                title,
-                categoryGroup,
-                categoryDetail,
-                address,
-                latitude,
-                longitude,
+                "126204",
+                "TOUR_API",
+                "공산성",
+                "TOURISM",
+                "HERITAGE",
+                "충남 공주시 금성동",
+                new BigDecimal("36.4650"),
+                new BigDecimal("127.1270"),
+                null
+        );
+    }
+
+    private CoursePlaceSaveRequest createKakaoRequest() {
+        return new CoursePlaceSaveRequest(
+                null,
+                "kakao-1",
+                "KAKAO_LOCAL",
+                "공주 카페",
+                "CAFE_DESSERT",
+                "CAFE",
+                "충남 공주시 웅진로 10",
+                new BigDecimal("36.4500"),
+                new BigDecimal("127.1200"),
+                null
+        );
+    }
+
+    private CoursePlaceSaveRequest createDbPlaceRequest() {
+        return new CoursePlaceSaveRequest(
+                100L,
+                null,
+                "TOUR_API",
+                "공산성",
+                "TOURISM",
+                "HERITAGE",
+                "충남 공주시 금성동",
+                new BigDecimal("36.4650"),
+                new BigDecimal("127.1270"),
+                null
+        );
+    }
+
+    private TourApiPlaceItem createTourApiPlaceItem() {
+        return new TourApiPlaceItem(
+                "126204",
+                "공산성",
+                "충남 공주시 금성동",
+                "36.4650",
+                "127.1270",
+                null,
+                "44",
+                "150",
+                "HS",
+                null,
+                "HS01",
                 null
         );
     }

--- a/src/test/java/com/chaerok/backend/course/service/CourseExternalPlaceResolverTest.java
+++ b/src/test/java/com/chaerok/backend/course/service/CourseExternalPlaceResolverTest.java
@@ -1,0 +1,379 @@
+package com.chaerok.backend.course.service;
+
+import com.chaerok.backend.course.dto.CoursePlaceSaveRequest;
+import com.chaerok.backend.place.entity.PlaceSource;
+import com.chaerok.backend.place.external.TourApiPlaceClient;
+import com.chaerok.backend.place.external.TourApiPlaceItem;
+import com.chaerok.backend.region.entity.Region;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CourseExternalPlaceResolverTest {
+
+    @Mock
+    private TourApiPlaceClient tourApiPlaceClient;
+
+    @Mock
+    private Region region;
+
+    private CourseExternalPlaceResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new CourseExternalPlaceResolver(
+                tourApiPlaceClient
+        );
+    }
+
+    @Test
+    @DisplayName("DB 장소 요청은 TourAPI를 호출하지 않는다")
+    void doesNotCallTourApiForExistingDbPlace() {
+        // given
+        CoursePlaceSaveRequest request =
+                createDbPlaceRequest();
+
+        // when
+        Optional<TourApiPlaceItem> result =
+                resolver.resolveTourApiPlace(
+                        region,
+                        request
+                );
+
+        // then
+        assertThat(result).isEmpty();
+
+        verify(tourApiPlaceClient, never())
+                .getPlaceDetail(org.mockito.ArgumentMatchers.anyString());
+
+        verify(tourApiPlaceClient, never())
+                .searchPlacesByKeyword(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString()
+                );
+    }
+
+    @Test
+    @DisplayName("TourAPI 요청은 contentId로 상세 조회한다")
+    void resolvesTourApiPlaceByContentId() {
+        // given
+        CoursePlaceSaveRequest request =
+                createTourApiRequest();
+
+        TourApiPlaceItem item =
+                createTourApiPlaceItem(
+                        "126204",
+                        "공산성",
+                        "44",
+                        "150"
+                );
+
+        when(region.getLdongRegnCd())
+                .thenReturn("44");
+
+        when(region.getLdongSignguCd())
+                .thenReturn("150");
+
+        when(tourApiPlaceClient.getPlaceDetail("126204"))
+                .thenReturn(item);
+
+        // when
+        Optional<TourApiPlaceItem> result =
+                resolver.resolveTourApiPlace(
+                        region,
+                        request
+                );
+
+        // then
+        assertThat(result)
+                .contains(item);
+
+        verify(tourApiPlaceClient)
+                .getPlaceDetail("126204");
+
+        verify(tourApiPlaceClient, never())
+                .searchPlacesByKeyword(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString()
+                );
+    }
+
+    @Test
+    @DisplayName("TourAPI 상세 조회 결과가 없으면 예외가 발생한다")
+    void throwsWhenTourApiDetailIsMissing() {
+        // given
+        CoursePlaceSaveRequest request =
+                createTourApiRequest();
+
+        when(tourApiPlaceClient.getPlaceDetail("126204"))
+                .thenReturn(null);
+
+        // when & then
+        assertThatThrownBy(() ->
+                resolver.resolveTourApiPlace(
+                        region,
+                        request
+                )
+        )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "TourAPI 장소 정보를 찾을 수 없습니다."
+                );
+    }
+
+    @Test
+    @DisplayName("TourAPI 장소가 코스 지역과 다르면 예외가 발생한다")
+    void throwsWhenTourApiPlaceRegionDoesNotMatch() {
+        // given
+        CoursePlaceSaveRequest request =
+                createTourApiRequest();
+
+        TourApiPlaceItem item =
+                createTourApiPlaceItem(
+                        "126204",
+                        "공산성",
+                        "44",
+                        "170"
+                );
+
+        when(region.getLdongRegnCd())
+                .thenReturn("44");
+
+        when(region.getLdongSignguCd())
+                .thenReturn("150");
+
+        when(tourApiPlaceClient.getPlaceDetail("126204"))
+                .thenReturn(item);
+
+        // when & then
+        assertThatThrownBy(() ->
+                resolver.resolveTourApiPlace(
+                        region,
+                        request
+                )
+        )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "TourAPI 장소가 코스 지역과 일치하지 않습니다."
+                );
+    }
+
+    @Test
+    @DisplayName("Kakao 외부 장소는 제목과 지역코드로 TourAPI를 검색한다")
+    void searchesTourApiForKakaoExternalPlace() {
+        // given
+        CoursePlaceSaveRequest request =
+                createKakaoRequest(
+                        "공산성",
+                        "충남 공주시 금성동"
+                );
+
+        TourApiPlaceItem item =
+                createTourApiPlaceItem(
+                        "126204",
+                        "공산성",
+                        "44",
+                        "150"
+                );
+
+        when(region.getLdongRegnCd())
+                .thenReturn("44");
+
+        when(region.getLdongSignguCd())
+                .thenReturn("150");
+
+        when(tourApiPlaceClient.searchPlacesByKeyword(
+                "공산성",
+                "44",
+                "150"
+        )).thenReturn(List.of(item));
+
+        // when
+        Optional<TourApiPlaceItem> result =
+                resolver.resolveTourApiPlace(
+                        region,
+                        request
+                );
+
+        // then
+        assertThat(result)
+                .contains(item);
+    }
+
+    @Test
+    @DisplayName("TourAPI 검색 결과에서 제목이 다른 장소는 매칭하지 않는다")
+    void doesNotMatchDifferentTitle() {
+        // given
+        CoursePlaceSaveRequest request =
+                createKakaoRequest(
+                        "공산성",
+                        "충남 공주시 금성동"
+                );
+
+        TourApiPlaceItem item =
+                createTourApiPlaceItem(
+                        "999999",
+                        "무령왕릉",
+                        "44",
+                        "150"
+                );
+
+        when(region.getLdongRegnCd())
+                .thenReturn("44");
+
+        when(region.getLdongSignguCd())
+                .thenReturn("150");
+
+        when(tourApiPlaceClient.searchPlacesByKeyword(
+                "공산성",
+                "44",
+                "150"
+        )).thenReturn(List.of(item));
+
+        // when
+        Optional<TourApiPlaceItem> result =
+                resolver.resolveTourApiPlace(
+                        region,
+                        request
+                );
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("제목과 주소가 일치하는 TourAPI 검색 결과를 매칭한다")
+    void matchesTourApiPlaceByTitleAndAddress() {
+        // given
+        CoursePlaceSaveRequest request =
+                createKakaoRequest(
+                        "공 산 성",
+                        "충남 공주시 금성동"
+                );
+
+        TourApiPlaceItem item =
+                new TourApiPlaceItem(
+                        "126204",
+                        "공산성",
+                        "충남 공주시 금성동",
+                        "36.4650",
+                        "127.1270",
+                        null,
+                        "44",
+                        "150",
+                        "HS",
+                        null,
+                        "HS01",
+                        null
+                );
+
+        when(region.getLdongRegnCd())
+                .thenReturn("44");
+
+        when(region.getLdongSignguCd())
+                .thenReturn("150");
+
+        when(tourApiPlaceClient.searchPlacesByKeyword(
+                "공 산 성",
+                "44",
+                "150"
+        )).thenReturn(List.of(item));
+
+        // when
+        Optional<TourApiPlaceItem> result =
+                resolver.resolveTourApiPlace(
+                        region,
+                        request
+                );
+
+        // then
+        assertThat(result)
+                .contains(item);
+    }
+
+    private CoursePlaceSaveRequest createDbPlaceRequest() {
+        return new CoursePlaceSaveRequest(
+                100L,
+                null,
+                PlaceSource.TOUR_API.name(),
+                "공산성",
+                "TOURISM",
+                "HERITAGE",
+                "충남 공주시 금성동",
+                new BigDecimal("36.4650"),
+                new BigDecimal("127.1270"),
+                null
+        );
+    }
+
+    private CoursePlaceSaveRequest createTourApiRequest() {
+        return new CoursePlaceSaveRequest(
+                null,
+                "126204",
+                PlaceSource.TOUR_API.name(),
+                "공산성",
+                "TOURISM",
+                "HERITAGE",
+                "충남 공주시 금성동",
+                new BigDecimal("36.4650"),
+                new BigDecimal("127.1270"),
+                null
+        );
+    }
+
+    private CoursePlaceSaveRequest createKakaoRequest(
+            String title,
+            String address
+    ) {
+        return new CoursePlaceSaveRequest(
+                null,
+                "kakao-1",
+                PlaceSource.KAKAO_LOCAL.name(),
+                title,
+                "TOURISM",
+                "HERITAGE",
+                address,
+                new BigDecimal("36.4650"),
+                new BigDecimal("127.1270"),
+                null
+        );
+    }
+
+    private TourApiPlaceItem createTourApiPlaceItem(
+            String contentId,
+            String title,
+            String regionCode,
+            String sigunguCode
+    ) {
+        return new TourApiPlaceItem(
+                contentId,
+                title,
+                "충남 공주시 금성동",
+                "36.4650",
+                "127.1270",
+                null,
+                regionCode,
+                sigunguCode,
+                "HS",
+                null,
+                "HS01",
+                null
+        );
+    }
+}

--- a/src/test/java/com/chaerok/backend/course/service/CoursePersistenceServiceTest.java
+++ b/src/test/java/com/chaerok/backend/course/service/CoursePersistenceServiceTest.java
@@ -1,0 +1,559 @@
+package com.chaerok.backend.course.service;
+
+import com.chaerok.backend.course.dto.CoursePlaceSaveRequest;
+import com.chaerok.backend.course.entity.Course;
+import com.chaerok.backend.course.entity.CoursePlace;
+import com.chaerok.backend.course.entity.CourseStatus;
+import com.chaerok.backend.course.repository.CoursePlaceRepository;
+import com.chaerok.backend.course.repository.CourseRepository;
+import com.chaerok.backend.place.entity.Place;
+import com.chaerok.backend.place.entity.PlaceCategoryDetail;
+import com.chaerok.backend.place.entity.PlaceCategoryGroup;
+import com.chaerok.backend.place.entity.PlaceSource;
+import com.chaerok.backend.place.external.TourApiPlaceItem;
+import com.chaerok.backend.place.repository.PlaceRepository;
+import com.chaerok.backend.region.entity.Region;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CoursePersistenceServiceTest {
+
+    private static final Long COURSE_ID = 10L;
+    private static final Long REGION_ID = 1L;
+
+    @Mock
+    private CourseRepository courseRepository;
+
+    @Mock
+    private CoursePlaceRepository coursePlaceRepository;
+
+    @Mock
+    private PlaceRepository placeRepository;
+
+    @Mock
+    private Course course;
+
+    @Mock
+    private Region region;
+
+    private CoursePersistenceService persistenceService;
+
+    @BeforeEach
+    void setUp() {
+        persistenceService = new CoursePersistenceService(
+                courseRepository,
+                coursePlaceRepository,
+                placeRepository
+        );
+    }
+
+    @Test
+    @DisplayName("유효한 Kakao 외부 장소는 신규 Place로 저장한다")
+    void addPlacesSavesValidKakaoPlace() {
+        // given
+        mockSuccessfulCourse();
+
+        when(region.getLdongRegnCd())
+                .thenReturn("44");
+        when(region.getLdongSignguCd())
+                .thenReturn("150");
+        when(region.getCityCountyName())
+                .thenReturn("공주시");
+
+        CoursePlaceSaveRequest request = createKakaoRequest(
+                "kakao-1",
+                "공주 카페",
+                "CAFE_DESSERT",
+                "CAFE",
+                "충남 공주시 웅진로 10",
+                new BigDecimal("36.4500"),
+                new BigDecimal("127.1200")
+        );
+
+        when(placeRepository.findByKakaoPlaceId("kakao-1"))
+                .thenReturn(Optional.empty());
+
+        when(placeRepository.save(any(Place.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        persistenceService.addPlacesToCourse(
+                course,
+                region,
+                List.of(
+                        ResolvedCoursePlace.of(request, null)
+                )
+        );
+
+        // then
+        ArgumentCaptor<Place> captor =
+                ArgumentCaptor.forClass(Place.class);
+
+        verify(placeRepository).save(captor.capture());
+
+        Place savedPlace = captor.getValue();
+
+        assertThat(savedPlace.getKakaoPlaceId())
+                .isEqualTo("kakao-1");
+        assertThat(savedPlace.getTitle())
+                .isEqualTo("공주 카페");
+        assertThat(savedPlace.getAddress())
+                .isEqualTo("충남 공주시 웅진로 10");
+        assertThat(savedPlace.getCategoryGroup())
+                .isEqualTo(PlaceCategoryGroup.CAFE_DESSERT);
+        assertThat(savedPlace.getCategoryDetail())
+                .isEqualTo(PlaceCategoryDetail.CAFE);
+        assertThat(savedPlace.getSource())
+                .isEqualTo(PlaceSource.KAKAO_LOCAL);
+
+        verify(coursePlaceRepository)
+                .save(any(CoursePlace.class));
+    }
+
+    @Test
+    @DisplayName("다른 시군의 Kakao 외부 장소는 저장하지 않는다")
+    void addPlacesRejectsKakaoPlaceOutsideRegion() {
+        // given
+        when(course.getId()).thenReturn(COURSE_ID);
+        when(region.getCityCountyName())
+                .thenReturn("공주시");
+
+        CoursePlaceSaveRequest request = createKakaoRequest(
+                "kakao-2",
+                "논산 카페",
+                "CAFE_DESSERT",
+                "CAFE",
+                "충남 논산시 중앙로 10",
+                new BigDecimal("36.2000"),
+                new BigDecimal("127.0000")
+        );
+
+        when(placeRepository.findByKakaoPlaceId("kakao-2"))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                persistenceService.addPlacesToCourse(
+                        course,
+                        region,
+                        List.of(
+                                ResolvedCoursePlace.of(request, null)
+                        )
+                )
+        )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Kakao 장소가 코스 지역과 일치하지 않습니다."
+                );
+
+        verify(placeRepository, never())
+                .save(any(Place.class));
+    }
+
+    @Test
+    @DisplayName("좌표가 없는 Kakao 외부 장소는 저장하지 않는다")
+    void addPlacesRejectsKakaoPlaceWithoutCoordinates() {
+        // given
+        when(course.getId()).thenReturn(COURSE_ID);
+
+        CoursePlaceSaveRequest request = createKakaoRequest(
+                "kakao-3",
+                "공주 카페",
+                "CAFE_DESSERT",
+                "CAFE",
+                "충남 공주시 웅진로 10",
+                null,
+                null
+        );
+
+        when(placeRepository.findByKakaoPlaceId("kakao-3"))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                persistenceService.addPlacesToCourse(
+                        course,
+                        region,
+                        List.of(
+                                ResolvedCoursePlace.of(request, null)
+                        )
+                )
+        )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Kakao 장소 좌표는 필수입니다.");
+
+        verify(placeRepository, never())
+                .save(any(Place.class));
+    }
+
+    @Test
+    @DisplayName("유효 범위를 벗어난 Kakao 외부 장소 좌표는 저장하지 않는다")
+    void addPlacesRejectsInvalidKakaoCoordinates() {
+        // given
+        when(course.getId()).thenReturn(COURSE_ID);
+
+        CoursePlaceSaveRequest request = createKakaoRequest(
+                "kakao-4",
+                "공주 카페",
+                "CAFE_DESSERT",
+                "CAFE",
+                "충남 공주시 웅진로 10",
+                new BigDecimal("91"),
+                new BigDecimal("127.1200")
+        );
+
+        when(placeRepository.findByKakaoPlaceId("kakao-4"))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                persistenceService.addPlacesToCourse(
+                        course,
+                        region,
+                        List.of(
+                                ResolvedCoursePlace.of(request, null)
+                        )
+                )
+        )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Kakao 장소 좌표가 올바르지 않습니다."
+                );
+
+        verify(placeRepository, never())
+                .save(any(Place.class));
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 Kakao 장소 세부 유형은 저장하지 않는다")
+    void addPlacesRejectsUnsupportedKakaoCategoryDetail() {
+        // given
+        when(course.getId()).thenReturn(COURSE_ID);
+        when(region.getCityCountyName())
+                .thenReturn("공주시");
+
+        CoursePlaceSaveRequest request = createKakaoRequest(
+                "kakao-5",
+                "공주 카페",
+                "CAFE_DESSERT",
+                "UNKNOWN",
+                "충남 공주시 웅진로 10",
+                new BigDecimal("36.4500"),
+                new BigDecimal("127.1200")
+        );
+
+        when(placeRepository.findByKakaoPlaceId("kakao-5"))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                persistenceService.addPlacesToCourse(
+                        course,
+                        region,
+                        List.of(
+                                ResolvedCoursePlace.of(request, null)
+                        )
+                )
+        )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "지원하지 않는 장소 세부 유형입니다."
+                );
+
+        verify(placeRepository, never())
+                .save(any(Place.class));
+    }
+
+    @Test
+    @DisplayName("장소 유형과 세부 유형이 일치하지 않으면 Kakao 장소를 저장하지 않는다")
+    void addPlacesRejectsMismatchedKakaoCategory() {
+        // given
+        when(course.getId()).thenReturn(COURSE_ID);
+        when(region.getCityCountyName())
+                .thenReturn("공주시");
+
+        CoursePlaceSaveRequest request = createKakaoRequest(
+                "kakao-6",
+                "공주 카페",
+                "FOOD",
+                "CAFE",
+                "충남 공주시 웅진로 10",
+                new BigDecimal("36.4500"),
+                new BigDecimal("127.1200")
+        );
+
+        when(placeRepository.findByKakaoPlaceId("kakao-6"))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                persistenceService.addPlacesToCourse(
+                        course,
+                        region,
+                        List.of(
+                                ResolvedCoursePlace.of(request, null)
+                        )
+                )
+        )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "장소 유형과 세부 유형이 일치하지 않습니다."
+                );
+
+        verify(placeRepository, never())
+                .save(any(Place.class));
+    }
+
+    @Test
+    @DisplayName("이미 저장된 kakaoPlaceId가 있으면 기존 Place를 재사용한다")
+    void addPlacesReusesExistingKakaoPlace() {
+        // given
+        mockSuccessfulCourse();
+
+        CoursePlaceSaveRequest request = createKakaoRequest(
+                "kakao-7",
+                "공주 카페",
+                "CAFE_DESSERT",
+                "CAFE",
+                "충남 공주시 웅진로 10",
+                new BigDecimal("36.4500"),
+                new BigDecimal("127.1200")
+        );
+
+        Place existingPlace = Place.create(
+                region,
+                null,
+                "kakao-7",
+                "기존 공주 카페",
+                "충남 공주시 웅진로 10",
+                new BigDecimal("36.4500"),
+                new BigDecimal("127.1200"),
+                null,
+                "44",
+                "150",
+                null,
+                null,
+                null,
+                PlaceCategoryGroup.CAFE_DESSERT,
+                PlaceCategoryDetail.CAFE,
+                false,
+                PlaceSource.KAKAO_LOCAL
+        );
+
+        when(placeRepository.findByKakaoPlaceId("kakao-7"))
+                .thenReturn(Optional.of(existingPlace));
+
+        // when
+        persistenceService.addPlacesToCourse(
+                course,
+                region,
+                List.of(
+                        ResolvedCoursePlace.of(request, null)
+                )
+        );
+
+        // then
+        verify(placeRepository, never())
+                .save(any(Place.class));
+
+        verify(coursePlaceRepository)
+                .save(any(CoursePlace.class));
+    }
+
+    @Test
+    @DisplayName("이미 저장된 TourAPI 장소가 있으면 tourContentId 기준으로 재사용한다")
+    void addPlacesReusesExistingTourApiPlace() {
+        // given
+        mockSuccessfulCourse();
+
+        CoursePlaceSaveRequest request =
+                createTourApiRequest();
+
+        TourApiPlaceItem item =
+                createTourApiPlaceItem();
+
+        Place existingPlace = Place.create(
+                region,
+                "126204",
+                null,
+                "공산성",
+                "충남 공주시 금성동",
+                new BigDecimal("36.4650"),
+                new BigDecimal("127.1270"),
+                null,
+                "44",
+                "150",
+                "HS",
+                null,
+                "HS01",
+                PlaceCategoryGroup.TOURISM,
+                PlaceCategoryDetail.HERITAGE,
+                true,
+                PlaceSource.TOUR_API
+        );
+
+        when(placeRepository.findByTourContentId("126204"))
+                .thenReturn(Optional.of(existingPlace));
+
+        // when
+        persistenceService.addPlacesToCourse(
+                course,
+                region,
+                List.of(
+                        ResolvedCoursePlace.of(request, item)
+                )
+        );
+
+        // then
+        verify(placeRepository, never())
+                .save(any(Place.class));
+
+        verify(coursePlaceRepository)
+                .save(any(CoursePlace.class));
+    }
+
+    @Test
+    @DisplayName("신규 TourAPI 장소는 외부 조회 결과를 사용해 Place로 저장한다")
+    void addPlacesSavesNewTourApiPlace() {
+        // given
+        mockSuccessfulCourse();
+
+        CoursePlaceSaveRequest request =
+                createTourApiRequest();
+
+        TourApiPlaceItem item =
+                createTourApiPlaceItem();
+
+        when(region.getLdongRegnCd())
+                .thenReturn("44");
+        when(region.getLdongSignguCd())
+                .thenReturn("150");
+
+        when(placeRepository.findByTourContentId("126204"))
+                .thenReturn(Optional.empty());
+
+        when(placeRepository.save(any(Place.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        persistenceService.addPlacesToCourse(
+                course,
+                region,
+                List.of(
+                        ResolvedCoursePlace.of(request, item)
+                )
+        );
+
+        // then
+        ArgumentCaptor<Place> captor =
+                ArgumentCaptor.forClass(Place.class);
+
+        verify(placeRepository).save(captor.capture());
+
+        Place savedPlace = captor.getValue();
+
+        assertThat(savedPlace.getTourContentId())
+                .isEqualTo("126204");
+        assertThat(savedPlace.getTitle())
+                .isEqualTo("공산성");
+        assertThat(savedPlace.getCategoryGroup())
+                .isEqualTo(PlaceCategoryGroup.TOURISM);
+        assertThat(savedPlace.getCategoryDetail())
+                .isEqualTo(PlaceCategoryDetail.HERITAGE);
+        assertThat(savedPlace.getSource())
+                .isEqualTo(PlaceSource.TOUR_API);
+    }
+
+    private void mockSuccessfulCourse() {
+        when(course.getId())
+                .thenReturn(COURSE_ID);
+
+        when(course.getRegion())
+                .thenReturn(region);
+
+        when(course.getTitle())
+                .thenReturn("공주 여행");
+
+        when(course.getStatus())
+                .thenReturn(CourseStatus.ACTIVE);
+
+        when(region.getId())
+                .thenReturn(REGION_ID);
+
+        when(coursePlaceRepository
+                .findByCourseIdOrderBySequenceAsc(COURSE_ID))
+                .thenReturn(List.of());
+    }
+
+    private CoursePlaceSaveRequest createKakaoRequest(
+            String externalPlaceId,
+            String title,
+            String categoryGroup,
+            String categoryDetail,
+            String address,
+            BigDecimal latitude,
+            BigDecimal longitude
+    ) {
+        return new CoursePlaceSaveRequest(
+                null,
+                externalPlaceId,
+                PlaceSource.KAKAO_LOCAL.name(),
+                title,
+                categoryGroup,
+                categoryDetail,
+                address,
+                latitude,
+                longitude,
+                null
+        );
+    }
+
+    private CoursePlaceSaveRequest createTourApiRequest() {
+        return new CoursePlaceSaveRequest(
+                null,
+                "126204",
+                PlaceSource.TOUR_API.name(),
+                "공산성",
+                "TOURISM",
+                "HERITAGE",
+                "충남 공주시 금성동",
+                new BigDecimal("36.4650"),
+                new BigDecimal("127.1270"),
+                null
+        );
+    }
+
+    private TourApiPlaceItem createTourApiPlaceItem() {
+        return new TourApiPlaceItem(
+                "126204",
+                "공산성",
+                "충남 공주시 금성동",
+                "36.4650",
+                "127.1270",
+                null,
+                "44",
+                "150",
+                "HS",
+                null,
+                "HS01",
+                null
+        );
+    }
+}


### PR DESCRIPTION
## ✨ 변경 사항

- Course 외부 API 호출과 DB 저장 로직의 트랜잭션 경계 분리
- `CourseCommandService`를 요청 조율 역할로 축소
- TourAPI 조회 로직을 `CourseExternalPlaceResolver`로 분리
- Course, Place, CoursePlace 저장 로직을 `CoursePersistenceService`로 분리
- 외부 조회 결과 전달을 위한 `ResolvedCoursePlace` 추가
- `CourseRecommendService`의 클래스 단위 read-only 트랜잭션 제거
- 분리된 책임에 맞춰 Course 서비스 단위 테스트 리팩토링 및 추가

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #70 

## 🧩 API / DB 변경 사항

- 없음

## ✅ 테스트

- [x] 서버 실행 확인
- [ ] Swagger 확인
- [ ] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- TourAPI 및 Kakao Local API 호출이 장시간 DB 트랜잭션에 포함되지 않도록 구조 개선
- DB 변경 작업은 `CoursePersistenceService`의 `@Transactional` 범위에서 처리
- API 요청/응답 구조 및 DB 스키마 변경 없음
- `CourseCommandServiceTest`, `CoursePersistenceServiceTest`, `CourseExternalPlaceResolverTest`, `CourseRecommendServiceTest` 통과
- 전체 테스트 및 빌드 통과