### PR TITLE
fix(global): 처리되지 않은 서버 예외 로그 추가

### DIFF
--- a/src/main/java/com/chaerok/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chaerok/backend/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.chaerok.backend.global.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.List;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -112,6 +114,14 @@ public class GlobalExceptionHandler {
             Exception exception,
             HttpServletRequest request
     ) {
+        log.error(
+                "Unhandled exception. method={}, path={}, message={}",
+                request.getMethod(),
+                request.getRequestURI(),
+                exception.getMessage(),
+                exception
+        );
+
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ErrorResponse.of(


### PR DESCRIPTION
## ✨ 변경 사항

- 처리되지 않은 서버 예외 발생 시 요청 정보와 예외 stack trace가 로그에 남도록 공통 예외 처리 개선
- 기존 500 응답 형식은 유지하고 서버 로그만 추가

## 📌 담당 영역

- [x] 공통 설정 / 인프라
- [ ] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #72 

## 🧩 API / DB 변경 사항

- API 응답 형식 변경 없음
- DB 변경 없음

## ✅ 테스트

- [x] 서버 실행 확인
- [ ] Swagger 확인
- [ ] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- `GlobalExceptionHandler`의 `Exception.class` 처리 시 method, path, exception message와 stack trace를 `ERROR` 로그로 기록하도록 수정
- 클라이언트에는 기존과 동일하게 `INTERNAL_SERVER_ERROR` 응답을 반환
- 배포 후 `GET /api/courses/recommend` 500 오류를 재현하여 실제 예외 원인을 확인할 예정