### PR TITLE
fix(course): 추천 코스 조회 Lazy 로딩 오류 수정

### DIFF
--- a/src/main/java/com/chaerok/backend/course/service/CourseRecommendService.java
+++ b/src/main/java/com/chaerok/backend/course/service/CourseRecommendService.java
@@ -14,6 +14,7 @@ import com.chaerok.backend.place.repository.PlaceRepository;
 import com.chaerok.backend.region.repository.RegionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
@@ -23,6 +24,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CourseRecommendService {
 
     private static final String RECOMMENDATION_TYPE_REGION = "REGION";


### PR DESCRIPTION
## ✨ 변경 사항

- 추천 코스 조회 과정에서 `Place.region` LAZY 연관관계 접근 시 발생하던 `LazyInitializationException` 수정
- `CourseRecommendService`에 읽기 전용 트랜잭션을 적용하여 추천 처리 동안 Hibernate 세션 유지
- `Place.region`의 `FetchType.LAZY` 설정은 유지

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #74 

## 🧩 API / DB 변경 사항

- API 요청 및 응답 형식 변경 없음
- DB 변경 없음
- `CourseRecommendService`에 `@Transactional(readOnly = true)` 적용

## ✅ 테스트

- [x] 서버 실행 확인
- [x] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- 기존 오류:
  - `Could not initialize proxy [com.chaerok.backend.region.entity.Region#4] - no session`
- `Place.region`을 EAGER로 변경하지 않고 서비스 트랜잭션 경계를 추가하는 방식으로 수정
- `GET /api/courses/recommend?regionId={regionId}` 정상 응답 확인
- `anchorPlaceId`를 포함한 추천 코스 조회도 Swagger에서 확인