### PR TITLE
feat(auth): Apple 로그인 연동

### DIFF
--- a/src/main/java/com/chaerok/backend/auth/oauth/verifier/AppleTokenVerifier.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/verifier/AppleTokenVerifier.java
@@ -1,0 +1,81 @@
+package com.chaerok.backend.auth.oauth.verifier;
+
+import com.chaerok.backend.auth.oauth.dto.OAuthUserInfo;
+import com.chaerok.backend.global.exception.InvalidTokenException;
+import com.chaerok.backend.user.entity.OAuthProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppleTokenVerifier implements OAuthTokenVerifier {
+
+    private final JwtDecoder jwtDecoder;
+
+    public AppleTokenVerifier(
+            @Value("${oauth.apple.client-id}") String clientId,
+            @Value("${oauth.apple.issuer}") String issuer,
+            @Value("${oauth.apple.jwk-set-uri}") String jwkSetUri
+    ) {
+        NimbusJwtDecoder decoder =
+                NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
+
+        OAuth2TokenValidator<Jwt> issuerValidator =
+                JwtValidators.createDefaultWithIssuer(issuer);
+
+        OAuth2TokenValidator<Jwt> audienceValidator = jwt -> {
+            if (jwt.getAudience().contains(clientId)) {
+                return OAuth2TokenValidatorResult.success();
+            }
+
+            OAuth2Error error = new OAuth2Error(
+                    "invalid_token",
+                    "Apple ID Token의 audience가 일치하지 않습니다.",
+                    null
+            );
+
+            return OAuth2TokenValidatorResult.failure(error);
+        };
+
+        decoder.setJwtValidator(
+                new DelegatingOAuth2TokenValidator<>(
+                        issuerValidator,
+                        audienceValidator
+                )
+        );
+
+        this.jwtDecoder = decoder;
+    }
+
+    @Override
+    public OAuthProvider getProvider() {
+        return OAuthProvider.APPLE;
+    }
+
+    @Override
+    public OAuthUserInfo verify(String idToken) {
+        try {
+            Jwt jwt = jwtDecoder.decode(idToken);
+
+            return new OAuthUserInfo(
+                    OAuthProvider.APPLE,
+                    jwt.getSubject(),
+                    null,
+                    jwt.getClaimAsString("email")
+            );
+        } catch (JwtException exception) {
+            throw new InvalidTokenException(
+                    "유효하지 않은 Apple ID Token입니다.",
+                    exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/chaerok/backend/user/entity/OAuthProvider.java
+++ b/src/main/java/com/chaerok/backend/user/entity/OAuthProvider.java
@@ -2,5 +2,6 @@ package com.chaerok.backend.user.entity;
 
 public enum OAuthProvider {
     KAKAO,
-    GOOGLE
+    GOOGLE,
+    APPLE
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,6 +68,11 @@ oauth:
     issuer: https://accounts.google.com
     jwk-set-uri: https://www.googleapis.com/oauth2/v3/certs
 
+  apple:
+    client-id: ${APPLE_CLIENT_ID:}
+    issuer: https://appleid.apple.com
+    jwk-set-uri: https://appleid.apple.com/auth/keys
+
 jwt:
   secret: ${JWT_SECRET}
   access-expiration: ${JWT_ACCESS_EXPIRATION}

--- a/src/test/java/com/chaerok/backend/auth/oauth/verifier/AppleTokenVerifierTest.java
+++ b/src/test/java/com/chaerok/backend/auth/oauth/verifier/AppleTokenVerifierTest.java
@@ -1,0 +1,43 @@
+package com.chaerok.backend.auth.oauth.verifier;
+
+import com.chaerok.backend.global.exception.InvalidTokenException;
+import com.chaerok.backend.user.entity.OAuthProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AppleTokenVerifierTest {
+
+    private AppleTokenVerifier appleTokenVerifier;
+
+    @BeforeEach
+    void setUp() {
+        appleTokenVerifier = new AppleTokenVerifier(
+                "com.teamchaerok.chaerok",
+                "https://appleid.apple.com",
+                "https://appleid.apple.com/auth/keys"
+        );
+    }
+
+    @Test
+    void Apple_Provider를_반환한다() {
+        // when
+        OAuthProvider provider = appleTokenVerifier.getProvider();
+
+        // then
+        assertThat(provider).isEqualTo(OAuthProvider.APPLE);
+    }
+
+    @Test
+    void 유효하지_않은_Apple_ID_Token이면_예외가_발생한다() {
+        // given
+        String invalidIdToken = "invalid-token";
+
+        // when & then
+        assertThatThrownBy(() -> appleTokenVerifier.verify(invalidIdToken))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessage("유효하지 않은 Apple ID Token입니다.");
+    }
+}


### PR DESCRIPTION
## ✨ 변경 사항

* Apple OAuth Provider 추가
* Apple ID Token 검증 로직 구현
* Apple issuer, audience, 공개키 기반 JWT 검증 처리
* 기존 OAuth 로그인 흐름에서 Apple 로그인 연동
* Apple 로그인 검증 테스트 추가

## 📌 담당 영역

* [ ] 공통 설정 / 인프라
* [x] Backend 1: 사용자·관광 데이터·코스/Odii
* [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
* [ ] DB / Supabase
* [ ] 문서 / 기타

## 🔗 관련 이슈

* closes #76 

## 🧩 API / DB 변경 사항

* `POST /api/auth/login`

  * `provider`에 `APPLE` 추가
* Apple OAuth 설정 추가

  * `APPLE_CLIENT_ID`
  * issuer: `https://appleid.apple.com`
  * JWK Set URI: `https://appleid.apple.com/auth/keys`
* DB 변경 없음

## ✅ 테스트

* [x] 서버 실행 확인
* [x] Swagger 확인
* [x] 수동 테스트 완료
* [ ] 해당 없음

## 💬 참고 사항

* 기존 `OAuthTokenVerifier` 기반 인증 구조를 재사용하여 Apple 로그인을 확장함
* Apple 사용자는 ID Token의 `sub` 값을 고유 식별자로 사용함
* 실제 `APPLE_CLIENT_ID`는 Apple Developer 설정 완료 후 환경변수로 등록 필요
* 실제 Apple Identity Token을 이용한 로그인 성공 흐름은 Flutter iOS 연동 후 추가 확인 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Apple 로그인을 OAuth 제공자로 지원합니다.
  * Apple ID Token의 발급자, 대상 클라이언트, 서명 키를 검증해 안전하게 로그인 정보를 처리합니다.
  * Apple 인증에 필요한 설정을 환경 변수로 구성할 수 있습니다.

* **버그 수정**
  * 유효하지 않은 Apple ID Token을 명확한 인증 오류로 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->