### PR TITLE
refactor(user): 회원탈퇴 외부 API와 트랜잭션 분리

### DIFF
--- a/src/main/java/com/chaerok/backend/user/service/UserWithdrawalPersistenceService.java
+++ b/src/main/java/com/chaerok/backend/user/service/UserWithdrawalPersistenceService.java
@@ -1,0 +1,20 @@
+package com.chaerok.backend.user.service;
+
+import com.chaerok.backend.auth.service.RefreshTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserWithdrawalPersistenceService {
+
+    private final RefreshTokenService refreshTokenService;
+    private final UserService userService;
+
+    @Transactional
+    public void deleteUserData(Long userId) {
+        refreshTokenService.deleteAllByUserId(userId);
+        userService.deleteUser(userId);
+    }
+}

--- a/src/main/java/com/chaerok/backend/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/chaerok/backend/user/service/UserWithdrawalService.java
@@ -1,22 +1,19 @@
 package com.chaerok.backend.user.service;
 
 import com.chaerok.backend.auth.oauth.unlink.KakaoOAuthUnlinkService;
-import com.chaerok.backend.auth.service.RefreshTokenService;
 import com.chaerok.backend.user.entity.OAuthProvider;
 import com.chaerok.backend.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserWithdrawalService {
 
     private final UserService userService;
-    private final RefreshTokenService refreshTokenService;
     private final KakaoOAuthUnlinkService kakaoOAuthUnlinkService;
+    private final UserWithdrawalPersistenceService persistenceService;
 
-    @Transactional
     public void withdraw(Long userId) {
         User user = userService.findById(userId);
 
@@ -26,8 +23,6 @@ public class UserWithdrawalService {
             );
         }
 
-        refreshTokenService.deleteAllByUserId(user.getId());
-
-        userService.deleteUser(user.getId());
+        persistenceService.deleteUserData(user.getId());
     }
 }

--- a/src/test/java/com/chaerok/backend/user/service/UserWithdrawalPersistenceServiceTest.java
+++ b/src/test/java/com/chaerok/backend/user/service/UserWithdrawalPersistenceServiceTest.java
@@ -1,0 +1,52 @@
+package com.chaerok.backend.user.service;
+
+import com.chaerok.backend.auth.service.RefreshTokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.inOrder;
+
+@ExtendWith(MockitoExtension.class)
+class UserWithdrawalPersistenceServiceTest {
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private UserService userService;
+
+    private UserWithdrawalPersistenceService persistenceService;
+
+    @BeforeEach
+    void setUp() {
+        persistenceService = new UserWithdrawalPersistenceService(
+                refreshTokenService,
+                userService
+        );
+    }
+
+    @Test
+    void 회원탈퇴_DB_처리_시_리프레시_토큰과_사용자를_순서대로_삭제한다() {
+        // given
+        Long userId = 1L;
+
+        // when
+        persistenceService.deleteUserData(userId);
+
+        // then
+        InOrder inOrder = inOrder(
+                refreshTokenService,
+                userService
+        );
+
+        inOrder.verify(refreshTokenService)
+                .deleteAllByUserId(userId);
+
+        inOrder.verify(userService)
+                .deleteUser(userId);
+    }
+}

--- a/src/test/java/com/chaerok/backend/user/service/UserWithdrawalServiceTest.java
+++ b/src/test/java/com/chaerok/backend/user/service/UserWithdrawalServiceTest.java
@@ -1,7 +1,6 @@
 package com.chaerok.backend.user.service;
 
 import com.chaerok.backend.auth.oauth.unlink.KakaoOAuthUnlinkService;
-import com.chaerok.backend.auth.service.RefreshTokenService;
 import com.chaerok.backend.user.entity.OAuthProvider;
 import com.chaerok.backend.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,10 +19,10 @@ class UserWithdrawalServiceTest {
     private UserService userService;
 
     @Mock
-    private RefreshTokenService refreshTokenService;
+    private KakaoOAuthUnlinkService kakaoOAuthUnlinkService;
 
     @Mock
-    private KakaoOAuthUnlinkService kakaoOAuthUnlinkService;
+    private UserWithdrawalPersistenceService persistenceService;
 
     @Mock
     private User user;
@@ -34,13 +33,13 @@ class UserWithdrawalServiceTest {
     void setUp() {
         userWithdrawalService = new UserWithdrawalService(
                 userService,
-                refreshTokenService,
-                kakaoOAuthUnlinkService
+                kakaoOAuthUnlinkService,
+                persistenceService
         );
     }
 
     @Test
-    void 카카오_사용자_탈퇴_시_연결을_해제하고_토큰과_사용자를_삭제한다() {
+    void 카카오_사용자_탈퇴_시_연결을_해제한_뒤_DB_삭제를_위임한다() {
         // given
         Long userId = 1L;
         String providerUserId = "123456789";
@@ -57,20 +56,21 @@ class UserWithdrawalServiceTest {
         InOrder inOrder = inOrder(
                 userService,
                 kakaoOAuthUnlinkService,
-                refreshTokenService
+                persistenceService
         );
 
-        inOrder.verify(userService).findById(userId);
+        inOrder.verify(userService)
+                .findById(userId);
+
         inOrder.verify(kakaoOAuthUnlinkService)
                 .unlink(providerUserId);
-        inOrder.verify(refreshTokenService)
-                .deleteAllByUserId(userId);
-        inOrder.verify(userService)
-                .deleteUser(userId);
+
+        inOrder.verify(persistenceService)
+                .deleteUserData(userId);
     }
 
     @Test
-    void 구글_사용자_탈퇴_시_카카오_연결_해제_없이_토큰과_사용자를_삭제한다() {
+    void 구글_사용자_탈퇴_시_카카오_연결_해제_없이_DB_삭제를_위임한다() {
         // given
         Long userId = 2L;
 
@@ -85,10 +85,7 @@ class UserWithdrawalServiceTest {
         verify(kakaoOAuthUnlinkService, never())
                 .unlink(anyString());
 
-        verify(refreshTokenService)
-                .deleteAllByUserId(userId);
-
-        verify(userService)
-                .deleteUser(userId);
+        verify(persistenceService)
+                .deleteUserData(userId);
     }
 }


### PR DESCRIPTION
## ✨ 변경 사항

- 회원탈퇴 시 Kakao unlink 외부 API 호출과 DB 삭제 트랜잭션 분리
- `UserWithdrawalService`에서 Kakao unlink 후 DB 삭제 전용 서비스 호출하도록 구조 변경
- `UserWithdrawalPersistenceService` 추가
- Refresh Token 삭제와 User 삭제를 하나의 DB 트랜잭션으로 처리
- 회원탈퇴 서비스 책임 분리에 맞춰 단위 테스트 수정 및 추가

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #78 

## 🧩 API / DB 변경 사항

- 없음

## ✅ 테스트

- [x] 서버 실행 확인
- [ ] Swagger 확인
- [ ] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- Kakao unlink는 DB 트랜잭션 밖에서 수행
- Refresh Token 및 User 삭제는 `UserWithdrawalPersistenceService`의 `@Transactional` 범위에서 처리
- API 요청/응답 구조 및 DB 스키마 변경 없음
- `UserWithdrawalServiceTest`, `UserWithdrawalPersistenceServiceTest` 통과
- 전체 테스트 및 빌드 통과
- 실제 Kakao unlink가 발생하는 수동 탈퇴 테스트는 별도 테스트 계정이 필요한 관계로 수행하지 않음