### PR TITLE
feat(auth): Apple 로그인 nonce 검증 추가

### DIFF
--- a/src/main/java/com/chaerok/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/chaerok/backend/auth/controller/AuthController.java
@@ -19,7 +19,7 @@ public class AuthController {
 
     @Operation(
             summary = "OAuth 로그인",
-            description = "카카오 또는 구글 ID Token을 검증합니다. 기존 회원은 Access Token과 Refresh Token을 발급하고, 신규 회원은 회원가입에 사용할 Signup Token을 반환합니다."
+            description = "카카오, 구글 또는 Apple ID Token을 검증합니다. Apple 로그인은 nonce를 함께 검증합니다."
     )
     @PostMapping("/login")
     public ResponseEntity<OAuthLoginResponse> login(

--- a/src/main/java/com/chaerok/backend/auth/dto/OAuthLoginRequest.java
+++ b/src/main/java/com/chaerok/backend/auth/dto/OAuthLoginRequest.java
@@ -14,7 +14,7 @@ public record OAuthLoginRequest(
         String idToken,
 
         @Schema(
-                description = "Apple 로그인 nonce. Kakao/Google에서는 사용하지 않습니다."
+                description = "Apple 로그인 요청에 사용한 SHA-256 해시 nonce. Kakao/Google에서는 사용하지 않습니다."
         )
         String nonce
 ) {

--- a/src/main/java/com/chaerok/backend/auth/dto/OAuthLoginRequest.java
+++ b/src/main/java/com/chaerok/backend/auth/dto/OAuthLoginRequest.java
@@ -1,6 +1,7 @@
 package com.chaerok.backend.auth.dto;
 
 import com.chaerok.backend.user.entity.OAuthProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -10,6 +11,11 @@ public record OAuthLoginRequest(
         OAuthProvider provider,
 
         @NotBlank(message = "ID Token은 필수입니다.")
-        String idToken
+        String idToken,
+
+        @Schema(
+                description = "Apple 로그인 nonce. Kakao/Google에서는 사용하지 않습니다."
+        )
+        String nonce
 ) {
 }

--- a/src/main/java/com/chaerok/backend/auth/oauth/verifier/AppleTokenVerifier.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/verifier/AppleTokenVerifier.java
@@ -61,9 +61,23 @@ public class AppleTokenVerifier implements OAuthTokenVerifier {
     }
 
     @Override
-    public OAuthUserInfo verify(String idToken) {
+    public OAuthUserInfo verify(String idToken, String nonce) {
         try {
+            if (nonce == null || nonce.isBlank()) {
+                throw new InvalidTokenException(
+                        "Apple 로그인 nonce가 필요합니다."
+                );
+            }
+
             Jwt jwt = jwtDecoder.decode(idToken);
+
+            String tokenNonce = jwt.getClaimAsString("nonce");
+
+            if (tokenNonce == null || !nonce.equals(tokenNonce)) {
+                throw new InvalidTokenException(
+                        "Apple ID Token의 nonce가 일치하지 않습니다."
+                );
+            }
 
             return new OAuthUserInfo(
                     OAuthProvider.APPLE,

--- a/src/main/java/com/chaerok/backend/auth/oauth/verifier/GoogleTokenVerifier.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/verifier/GoogleTokenVerifier.java
@@ -61,7 +61,7 @@ public class GoogleTokenVerifier implements OAuthTokenVerifier {
     }
 
     @Override
-    public OAuthUserInfo verify(String idToken) {
+    public OAuthUserInfo verify(String idToken, String nonce) {
         try {
             Jwt jwt = jwtDecoder.decode(idToken);
 
@@ -73,7 +73,7 @@ public class GoogleTokenVerifier implements OAuthTokenVerifier {
             );
         } catch (JwtException exception) {
             throw new InvalidTokenException(
-                    "유효하지 않은 구글 ID Token입니다.",
+                    "유효하지 않은 Google ID Token입니다.",
                     exception
             );
         }

--- a/src/main/java/com/chaerok/backend/auth/oauth/verifier/KakaoTokenVerifier.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/verifier/KakaoTokenVerifier.java
@@ -61,7 +61,7 @@ public class KakaoTokenVerifier implements OAuthTokenVerifier {
     }
 
     @Override
-    public OAuthUserInfo verify(String idToken) {
+    public OAuthUserInfo verify(String idToken, String nonce) {
         try {
             Jwt jwt = jwtDecoder.decode(idToken);
 

--- a/src/main/java/com/chaerok/backend/auth/oauth/verifier/OAuthTokenVerifier.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/verifier/OAuthTokenVerifier.java
@@ -7,5 +7,5 @@ public interface OAuthTokenVerifier {
 
     OAuthProvider getProvider();
 
-    OAuthUserInfo verify(String idToken);
+    OAuthUserInfo verify(String idToken, String nonce);
 }

--- a/src/main/java/com/chaerok/backend/auth/service/AuthService.java
+++ b/src/main/java/com/chaerok/backend/auth/service/AuthService.java
@@ -34,7 +34,10 @@ public class AuthService {
                 verifierResolver.resolve(request.provider());
 
         OAuthUserInfo oauthUserInfo =
-                verifier.verify(request.idToken());
+                verifier.verify(
+                        request.idToken(),
+                        request.nonce()
+                );
 
         Optional<User> existingUser =
                 userService.findByOAuthProvider(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,7 +69,7 @@ oauth:
     jwk-set-uri: https://www.googleapis.com/oauth2/v3/certs
 
   apple:
-    client-id: ${APPLE_CLIENT_ID:}
+    client-id: ${APPLE_CLIENT_ID}
     issuer: https://appleid.apple.com
     jwk-set-uri: https://appleid.apple.com/auth/keys
 

--- a/src/test/java/com/chaerok/backend/auth/oauth/verifier/AppleTokenVerifierTest.java
+++ b/src/test/java/com/chaerok/backend/auth/oauth/verifier/AppleTokenVerifierTest.java
@@ -36,8 +36,32 @@ class AppleTokenVerifierTest {
         String invalidIdToken = "invalid-token";
 
         // when & then
-        assertThatThrownBy(() -> appleTokenVerifier.verify(invalidIdToken))
+        assertThatThrownBy(
+                () -> appleTokenVerifier.verify(invalidIdToken, "test-nonce")
+        )
                 .isInstanceOf(InvalidTokenException.class)
                 .hasMessage("유효하지 않은 Apple ID Token입니다.");
+    }
+
+    @Test
+    void Apple_로그인_nonce가_없으면_예외가_발생한다() {
+        // given
+        String idToken = "dummy-token";
+
+        // when & then
+        assertThatThrownBy(() -> appleTokenVerifier.verify(idToken, null))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessage("Apple 로그인 nonce가 필요합니다.");
+    }
+
+    @Test
+    void Apple_로그인_nonce가_빈_문자열이면_예외가_발생한다() {
+        // given
+        String idToken = "dummy-token";
+
+        // when & then
+        assertThatThrownBy(() -> appleTokenVerifier.verify(idToken, " "))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessage("Apple 로그인 nonce가 필요합니다.");
     }
 }


### PR DESCRIPTION
## ✨ 변경 사항

* OAuth 로그인 요청 DTO에 `nonce` 필드 추가
* `OAuthTokenVerifier` 검증 메서드에 nonce 전달 구조 반영
* Kakao·Google verifier의 기존 로그인 로직 유지
* `AuthService`에서 ID Token과 nonce를 verifier로 전달
* Apple 로그인 시 nonce 필수 검증 추가
* Apple ID Token의 `nonce` claim 일치 검증 추가
* nonce 관련 Swagger 설명 보완
* Apple nonce 누락 및 잘못된 토큰 예외 테스트 추가

## 📌 담당 영역

* [ ] 공통 설정 / 인프라
* [x] Backend 1: 사용자·관광 데이터·코스/Odii
* [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
* [ ] DB / Supabase
* [ ] 문서 / 기타

## 🔗 관련 이슈

* closes #80 

## 🧩 API / DB 변경 사항

* `POST /api/auth/login`

  * 요청 필드에 선택값 `nonce` 추가
  * `APPLE` 로그인 시 nonce 전달 필요
  * `KAKAO`, `GOOGLE` 로그인은 기존과 동일하게 nonce 없이 요청 가능
* DB 변경 없음

## ✅ 테스트

* [x] 서버 실행 확인
* [x] Swagger 확인
* [x] 수동 테스트 완료
* [ ] 해당 없음

## 💬 참고 사항

* Apple 로그인 요청과 ID Token의 연관성을 확인하기 위해 nonce 검증 추가
* 서버 발급·저장 방식은 적용하지 않고 클라이언트 생성 nonce를 검증하는 방식으로 구현
* 실제 Apple 정상 ID Token 기반 nonce 일치 검증은 iOS 연동 후 추가 확인 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **보안 개선**
  - Apple 로그인 시 nonce 검증을 추가해 ID 토큰 위·변조 방어를 강화했습니다.
  - nonce가 없거나 비어 있으면 로그인이 거부됩니다.
  - Apple OAuth 설정에 필요한 클라이언트 ID를 명시적으로 구성해야 합니다.

- **문서**
  - 로그인 API 설명에 Apple ID 토큰 및 nonce 검증 내용을 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->