### PR TITLE
feat(auth): Apple 회원탈퇴 연동 해제 처리

### DIFF
--- a/src/main/java/com/chaerok/backend/auth/oauth/dto/AppleTokenResponse.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/dto/AppleTokenResponse.java
@@ -1,0 +1,19 @@
+package com.chaerok.backend.auth.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AppleTokenResponse(
+
+        @JsonProperty("access_token")
+        String accessToken,
+
+        @JsonProperty("refresh_token")
+        String refreshToken,
+
+        @JsonProperty("token_type")
+        String tokenType,
+
+        @JsonProperty("expires_in")
+        Long expiresIn
+) {
+}

--- a/src/main/java/com/chaerok/backend/auth/oauth/dto/AppleTokenResponse.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/dto/AppleTokenResponse.java
@@ -10,6 +10,9 @@ public record AppleTokenResponse(
         @JsonProperty("refresh_token")
         String refreshToken,
 
+        @JsonProperty("id_token")
+        String idToken,
+
         @JsonProperty("token_type")
         String tokenType,
 

--- a/src/main/java/com/chaerok/backend/auth/oauth/service/AppleOAuthRevokeService.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/service/AppleOAuthRevokeService.java
@@ -1,16 +1,22 @@
 package com.chaerok.backend.auth.oauth.service;
 
 import com.chaerok.backend.auth.oauth.dto.AppleTokenResponse;
+import com.chaerok.backend.auth.oauth.verifier.AppleTokenVerifier;
 import io.jsonwebtoken.Jwts;
+import io.netty.channel.ChannelOption;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
 
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.Date;
@@ -21,6 +27,7 @@ public class AppleOAuthRevokeService {
     private static final String APPLE_AUDIENCE = "https://appleid.apple.com";
 
     private final WebClient webClient;
+    private final AppleTokenVerifier appleTokenVerifier;
     private final String clientId;
     private final String teamId;
     private final String keyId;
@@ -30,6 +37,7 @@ public class AppleOAuthRevokeService {
 
     public AppleOAuthRevokeService(
             WebClient.Builder webClientBuilder,
+            AppleTokenVerifier appleTokenVerifier,
             @Value("${oauth.apple.client-id}") String clientId,
             @Value("${oauth.apple.team-id}") String teamId,
             @Value("${oauth.apple.key-id}") String keyId,
@@ -37,7 +45,14 @@ public class AppleOAuthRevokeService {
             @Value("${oauth.apple.token-uri}") String tokenUri,
             @Value("${oauth.apple.revoke-uri}") String revokeUri
     ) {
-        this.webClient = webClientBuilder.build();
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .responseTimeout(Duration.ofSeconds(10));
+
+        this.webClient = webClientBuilder
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+        this.appleTokenVerifier = appleTokenVerifier;
         this.clientId = clientId;
         this.teamId = teamId;
         this.keyId = keyId;
@@ -101,17 +116,40 @@ public class AppleOAuthRevokeService {
                 .block();
     }
 
-    public void revoke(String authorizationCode) {
+    public void revoke(
+            String authorizationCode,
+            String providerUserId
+    ) {
         AppleTokenResponse tokenResponse =
                 exchangeAuthorizationCode(authorizationCode);
 
-        if (tokenResponse == null || tokenResponse.refreshToken() == null) {
+        if (tokenResponse == null
+                || tokenResponse.refreshToken() == null
+                || tokenResponse.idToken() == null) {
             throw new IllegalStateException(
-                    "Apple Refresh Token을 발급받지 못했습니다."
+                    "Apple Token을 발급받지 못했습니다."
             );
         }
 
+        validateAppleUser(
+                tokenResponse.idToken(),
+                providerUserId
+        );
+
         revokeToken(tokenResponse.refreshToken());
+    }
+
+    private void validateAppleUser(
+            String idToken,
+            String providerUserId
+    ) {
+        Jwt jwt = appleTokenVerifier.decodeAndValidate(idToken);
+
+        if (!providerUserId.equals(jwt.getSubject())) {
+            throw new IllegalArgumentException(
+                    "Apple 회원탈퇴 인증 사용자가 일치하지 않습니다."
+            );
+        }
     }
 
     private void revokeToken(String refreshToken) {

--- a/src/main/java/com/chaerok/backend/auth/oauth/service/AppleOAuthRevokeService.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/service/AppleOAuthRevokeService.java
@@ -1,0 +1,131 @@
+package com.chaerok.backend.auth.oauth.service;
+
+import com.chaerok.backend.auth.oauth.dto.AppleTokenResponse;
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+
+@Service
+public class AppleOAuthRevokeService {
+
+    private static final String APPLE_AUDIENCE = "https://appleid.apple.com";
+
+    private final WebClient webClient;
+    private final String clientId;
+    private final String teamId;
+    private final String keyId;
+    private final String privateKey;
+    private final String tokenUri;
+    private final String revokeUri;
+
+    public AppleOAuthRevokeService(
+            WebClient.Builder webClientBuilder,
+            @Value("${oauth.apple.client-id}") String clientId,
+            @Value("${oauth.apple.team-id}") String teamId,
+            @Value("${oauth.apple.key-id}") String keyId,
+            @Value("${oauth.apple.private-key}") String privateKey,
+            @Value("${oauth.apple.token-uri}") String tokenUri,
+            @Value("${oauth.apple.revoke-uri}") String revokeUri
+    ) {
+        this.webClient = webClientBuilder.build();
+        this.clientId = clientId;
+        this.teamId = teamId;
+        this.keyId = keyId;
+        this.privateKey = privateKey;
+        this.tokenUri = tokenUri;
+        this.revokeUri = revokeUri;
+    }
+
+    String createClientSecret() {
+        Instant now = Instant.now();
+
+        return Jwts.builder()
+                .header()
+                .keyId(keyId)
+                .and()
+                .issuer(teamId)
+                .subject(clientId)
+                .audience()
+                .add(APPLE_AUDIENCE)
+                .and()
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plusSeconds(300)))
+                .signWith(loadPrivateKey(), Jwts.SIG.ES256)
+                .compact();
+    }
+
+    private PrivateKey loadPrivateKey() {
+        try {
+            String normalizedKey = privateKey
+                    .replace("\\n", "\n")
+                    .replace("-----BEGIN PRIVATE KEY-----", "")
+                    .replace("-----END PRIVATE KEY-----", "")
+                    .replaceAll("\\s", "");
+
+            byte[] decoded = Base64.getDecoder().decode(normalizedKey);
+
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decoded);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+
+            return keyFactory.generatePrivate(keySpec);
+        } catch (Exception exception) {
+            throw new IllegalStateException(
+                    "Apple Private Key를 불러오지 못했습니다.",
+                    exception
+            );
+        }
+    }
+
+    private AppleTokenResponse exchangeAuthorizationCode(String authorizationCode) {
+        return webClient.post()
+                .uri(tokenUri)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters
+                        .fromFormData("client_id", clientId)
+                        .with("client_secret", createClientSecret())
+                        .with("code", authorizationCode)
+                        .with("grant_type", "authorization_code")
+                )
+                .retrieve()
+                .bodyToMono(AppleTokenResponse.class)
+                .block();
+    }
+
+    public void revoke(String authorizationCode) {
+        AppleTokenResponse tokenResponse =
+                exchangeAuthorizationCode(authorizationCode);
+
+        if (tokenResponse == null || tokenResponse.refreshToken() == null) {
+            throw new IllegalStateException(
+                    "Apple Refresh Token을 발급받지 못했습니다."
+            );
+        }
+
+        revokeToken(tokenResponse.refreshToken());
+    }
+
+    private void revokeToken(String refreshToken) {
+        webClient.post()
+                .uri(revokeUri)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters
+                        .fromFormData("client_id", clientId)
+                        .with("client_secret", createClientSecret())
+                        .with("token", refreshToken)
+                        .with("token_type_hint", "refresh_token")
+                )
+                .retrieve()
+                .toBodilessEntity()
+                .block();
+    }
+}

--- a/src/main/java/com/chaerok/backend/auth/oauth/verifier/AppleTokenVerifier.java
+++ b/src/main/java/com/chaerok/backend/auth/oauth/verifier/AppleTokenVerifier.java
@@ -62,29 +62,33 @@ public class AppleTokenVerifier implements OAuthTokenVerifier {
 
     @Override
     public OAuthUserInfo verify(String idToken, String nonce) {
-        try {
-            if (nonce == null || nonce.isBlank()) {
-                throw new InvalidTokenException(
-                        "Apple 로그인 nonce가 필요합니다."
-                );
-            }
-
-            Jwt jwt = jwtDecoder.decode(idToken);
-
-            String tokenNonce = jwt.getClaimAsString("nonce");
-
-            if (tokenNonce == null || !nonce.equals(tokenNonce)) {
-                throw new InvalidTokenException(
-                        "Apple ID Token의 nonce가 일치하지 않습니다."
-                );
-            }
-
-            return new OAuthUserInfo(
-                    OAuthProvider.APPLE,
-                    jwt.getSubject(),
-                    null,
-                    jwt.getClaimAsString("email")
+        if (nonce == null || nonce.isBlank()) {
+            throw new InvalidTokenException(
+                    "Apple 로그인 nonce가 필요합니다."
             );
+        }
+
+        Jwt jwt = decodeAndValidate(idToken);
+
+        String tokenNonce = jwt.getClaimAsString("nonce");
+
+        if (tokenNonce == null || !nonce.equals(tokenNonce)) {
+            throw new InvalidTokenException(
+                    "Apple ID Token의 nonce가 일치하지 않습니다."
+            );
+        }
+
+        return new OAuthUserInfo(
+                OAuthProvider.APPLE,
+                jwt.getSubject(),
+                null,
+                jwt.getClaimAsString("email")
+        );
+    }
+
+    public Jwt decodeAndValidate(String idToken) {
+        try {
+            return jwtDecoder.decode(idToken);
         } catch (JwtException exception) {
             throw new InvalidTokenException(
                     "유효하지 않은 Apple ID Token입니다.",

--- a/src/main/java/com/chaerok/backend/user/controller/UserController.java
+++ b/src/main/java/com/chaerok/backend/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.chaerok.backend.user.controller;
 import com.chaerok.backend.auth.security.AuthenticatedUser;
 import com.chaerok.backend.user.dto.UpdateNicknameRequest;
 import com.chaerok.backend.user.dto.UserResponse;
+import com.chaerok.backend.user.dto.UserWithdrawalRequest;
 import com.chaerok.backend.user.entity.User;
 import com.chaerok.backend.user.service.UserService;
 import com.chaerok.backend.user.service.UserWithdrawalService;
@@ -59,14 +60,16 @@ public class UserController {
 
     @Operation(
             summary = "회원 탈퇴",
-            description = "인증된 사용자의 계정과 인증 관련 데이터를 삭제합니다."
+            description = "인증된 사용자의 계정을 삭제합니다. Apple 사용자는 재인증 authorizationCode가 필요합니다."
     )
     @DeleteMapping("/me")
     public ResponseEntity<Void> withdraw(
-            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @RequestBody(required = false) UserWithdrawalRequest request
     ) {
         userWithdrawalService.withdraw(
-                authenticatedUser.userId()
+                authenticatedUser.userId(),
+                request != null ? request.authorizationCode() : null
         );
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/chaerok/backend/user/dto/UserWithdrawalRequest.java
+++ b/src/main/java/com/chaerok/backend/user/dto/UserWithdrawalRequest.java
@@ -1,0 +1,12 @@
+package com.chaerok.backend.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UserWithdrawalRequest(
+
+        @Schema(
+                description = "Apple 로그인 사용자의 회원탈퇴 시 재인증으로 발급받은 authorization code"
+        )
+        String authorizationCode
+) {
+}

--- a/src/main/java/com/chaerok/backend/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/chaerok/backend/user/service/UserWithdrawalService.java
@@ -32,7 +32,10 @@ public class UserWithdrawalService {
                 );
             }
 
-            appleOAuthRevokeService.revoke(authorizationCode);
+            appleOAuthRevokeService.revoke(
+                    authorizationCode,
+                    user.getProviderUserId()
+            );
         }
 
         persistenceService.deleteUserData(user.getId());

--- a/src/main/java/com/chaerok/backend/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/chaerok/backend/user/service/UserWithdrawalService.java
@@ -1,5 +1,6 @@
 package com.chaerok.backend.user.service;
 
+import com.chaerok.backend.auth.oauth.service.AppleOAuthRevokeService;
 import com.chaerok.backend.auth.oauth.unlink.KakaoOAuthUnlinkService;
 import com.chaerok.backend.user.entity.OAuthProvider;
 import com.chaerok.backend.user.entity.User;
@@ -13,14 +14,25 @@ public class UserWithdrawalService {
     private final UserService userService;
     private final KakaoOAuthUnlinkService kakaoOAuthUnlinkService;
     private final UserWithdrawalPersistenceService persistenceService;
+    private final AppleOAuthRevokeService appleOAuthRevokeService;
 
-    public void withdraw(Long userId) {
+    public void withdraw(Long userId, String authorizationCode) {
         User user = userService.findById(userId);
 
         if (user.getProvider() == OAuthProvider.KAKAO) {
             kakaoOAuthUnlinkService.unlink(
                     user.getProviderUserId()
             );
+        }
+
+        if (user.getProvider() == OAuthProvider.APPLE) {
+            if (authorizationCode == null || authorizationCode.isBlank()) {
+                throw new IllegalArgumentException(
+                        "Apple 회원탈퇴에는 authorizationCode가 필요합니다."
+                );
+            }
+
+            appleOAuthRevokeService.revoke(authorizationCode);
         }
 
         persistenceService.deleteUserData(user.getId());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,8 +70,13 @@ oauth:
 
   apple:
     client-id: ${APPLE_CLIENT_ID}
+    team-id: ${APPLE_TEAM_ID:}
+    key-id: ${APPLE_KEY_ID:}
+    private-key: ${APPLE_PRIVATE_KEY:}
     issuer: https://appleid.apple.com
     jwk-set-uri: https://appleid.apple.com/auth/keys
+    token-uri: https://appleid.apple.com/auth/token
+    revoke-uri: https://appleid.apple.com/auth/revoke
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/test/java/com/chaerok/backend/auth/oauth/service/AppleOAuthRevokeServiceTest.java
+++ b/src/test/java/com/chaerok/backend/auth/oauth/service/AppleOAuthRevokeServiceTest.java
@@ -1,0 +1,28 @@
+package com.chaerok.backend.auth.oauth.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AppleOAuthRevokeServiceTest {
+
+    @Test
+    void 잘못된_Private_Key면_client_secret_생성에_실패한다() {
+        // given
+        AppleOAuthRevokeService service = new AppleOAuthRevokeService(
+                WebClient.builder(),
+                "com.teamchaerok.chaerok",
+                "test-team-id",
+                "test-key-id",
+                "invalid-private-key",
+                "https://appleid.apple.com/auth/token",
+                "https://appleid.apple.com/auth/revoke"
+        );
+
+        // when & then
+        assertThatThrownBy(service::createClientSecret)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Apple Private Key를 불러오지 못했습니다.");
+    }
+}

--- a/src/test/java/com/chaerok/backend/auth/oauth/service/AppleOAuthRevokeServiceTest.java
+++ b/src/test/java/com/chaerok/backend/auth/oauth/service/AppleOAuthRevokeServiceTest.java
@@ -1,17 +1,23 @@
 package com.chaerok.backend.auth.oauth.service;
 
+import com.chaerok.backend.auth.oauth.verifier.AppleTokenVerifier;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AppleOAuthRevokeServiceTest {
 
+    @Mock
+    private AppleTokenVerifier appleTokenVerifier;
+
     @Test
     void 잘못된_Private_Key면_client_secret_생성에_실패한다() {
         // given
         AppleOAuthRevokeService service = new AppleOAuthRevokeService(
                 WebClient.builder(),
+                appleTokenVerifier,
                 "com.teamchaerok.chaerok",
                 "test-team-id",
                 "test-key-id",

--- a/src/test/java/com/chaerok/backend/user/service/UserWithdrawalServiceTest.java
+++ b/src/test/java/com/chaerok/backend/user/service/UserWithdrawalServiceTest.java
@@ -102,7 +102,9 @@ class UserWithdrawalServiceTest {
         // given
         Long userId = 3L;
         String authorizationCode = "apple-authorization-code";
+        String providerUserId = "apple-user-id";
 
+        when(user.getProviderUserId()).thenReturn(providerUserId);
         when(userService.findById(userId)).thenReturn(user);
         when(user.getId()).thenReturn(userId);
         when(user.getProvider()).thenReturn(OAuthProvider.APPLE);
@@ -121,7 +123,7 @@ class UserWithdrawalServiceTest {
                 .findById(userId);
 
         inOrder.verify(appleOAuthRevokeService)
-                .revoke(authorizationCode);
+                .revoke(authorizationCode, providerUserId);
 
         inOrder.verify(persistenceService)
                 .deleteUserData(userId);

--- a/src/test/java/com/chaerok/backend/user/service/UserWithdrawalServiceTest.java
+++ b/src/test/java/com/chaerok/backend/user/service/UserWithdrawalServiceTest.java
@@ -1,5 +1,6 @@
 package com.chaerok.backend.user.service;
 
+import com.chaerok.backend.auth.oauth.service.AppleOAuthRevokeService;
 import com.chaerok.backend.auth.oauth.unlink.KakaoOAuthUnlinkService;
 import com.chaerok.backend.user.entity.OAuthProvider;
 import com.chaerok.backend.user.entity.User;
@@ -10,6 +11,7 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -20,6 +22,9 @@ class UserWithdrawalServiceTest {
 
     @Mock
     private KakaoOAuthUnlinkService kakaoOAuthUnlinkService;
+
+    @Mock
+    private AppleOAuthRevokeService appleOAuthRevokeService;
 
     @Mock
     private UserWithdrawalPersistenceService persistenceService;
@@ -34,7 +39,8 @@ class UserWithdrawalServiceTest {
         userWithdrawalService = new UserWithdrawalService(
                 userService,
                 kakaoOAuthUnlinkService,
-                persistenceService
+                persistenceService,
+                appleOAuthRevokeService
         );
     }
 
@@ -50,7 +56,7 @@ class UserWithdrawalServiceTest {
         when(user.getProviderUserId()).thenReturn(providerUserId);
 
         // when
-        userWithdrawalService.withdraw(userId);
+        userWithdrawalService.withdraw(userId, null);
 
         // then
         InOrder inOrder = inOrder(
@@ -67,10 +73,12 @@ class UserWithdrawalServiceTest {
 
         inOrder.verify(persistenceService)
                 .deleteUserData(userId);
+
+        verifyNoInteractions(appleOAuthRevokeService);
     }
 
     @Test
-    void 구글_사용자_탈퇴_시_카카오_연결_해제_없이_DB_삭제를_위임한다() {
+    void 구글_사용자_탈퇴_시_OAuth_연결_해제_없이_DB_삭제를_위임한다() {
         // given
         Long userId = 2L;
 
@@ -79,13 +87,65 @@ class UserWithdrawalServiceTest {
         when(user.getProvider()).thenReturn(OAuthProvider.GOOGLE);
 
         // when
-        userWithdrawalService.withdraw(userId);
+        userWithdrawalService.withdraw(userId, null);
 
         // then
-        verify(kakaoOAuthUnlinkService, never())
-                .unlink(anyString());
+        verifyNoInteractions(kakaoOAuthUnlinkService);
+        verifyNoInteractions(appleOAuthRevokeService);
 
         verify(persistenceService)
                 .deleteUserData(userId);
+    }
+
+    @Test
+    void 애플_사용자_탈퇴_시_revoke_후_DB_삭제를_위임한다() {
+        // given
+        Long userId = 3L;
+        String authorizationCode = "apple-authorization-code";
+
+        when(userService.findById(userId)).thenReturn(user);
+        when(user.getId()).thenReturn(userId);
+        when(user.getProvider()).thenReturn(OAuthProvider.APPLE);
+
+        // when
+        userWithdrawalService.withdraw(userId, authorizationCode);
+
+        // then
+        InOrder inOrder = inOrder(
+                userService,
+                appleOAuthRevokeService,
+                persistenceService
+        );
+
+        inOrder.verify(userService)
+                .findById(userId);
+
+        inOrder.verify(appleOAuthRevokeService)
+                .revoke(authorizationCode);
+
+        inOrder.verify(persistenceService)
+                .deleteUserData(userId);
+
+        verifyNoInteractions(kakaoOAuthUnlinkService);
+    }
+
+    @Test
+    void 애플_사용자_탈퇴_시_authorizationCode가_없으면_DB를_삭제하지_않는다() {
+        // given
+        Long userId = 3L;
+
+        when(userService.findById(userId)).thenReturn(user);
+        when(user.getProvider()).thenReturn(OAuthProvider.APPLE);
+
+        // when & then
+        assertThatThrownBy(
+                () -> userWithdrawalService.withdraw(userId, null)
+        )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Apple 회원탈퇴에는 authorizationCode가 필요합니다.");
+
+        verifyNoInteractions(appleOAuthRevokeService);
+        verify(persistenceService, never())
+                .deleteUserData(anyLong());
     }
 }


### PR DESCRIPTION
## ✨ 변경 사항

- Apple 로그인 사용자의 회원탈퇴 시 Apple 계정 연동 해제 처리
- Apple `authorizationCode`를 이용한 token 교환 및 revoke API 연동
- Apple Private Key 기반 `client_secret` JWT 생성
- Apple revoke 성공 후 기존 회원탈퇴 처리 연결
- Kakao·Google 기존 회원탈퇴 흐름 유지
- Apple 회원탈퇴 관련 테스트 추가

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #82 

## 🧩 API / DB 변경 사항

- `DELETE /api/users/me`
  - Apple 로그인 사용자의 회원탈퇴 시 `authorizationCode` 요청 필드 추가
  - Kakao·Google 사용자는 기존 방식 유지
- Apple 외부 API 연동 추가
  - `/auth/token`
  - `/auth/revoke`
- Apple revoke 관련 환경변수 설정 추가
  - `APPLE_TEAM_ID`
  - `APPLE_KEY_ID`
  - `APPLE_PRIVATE_KEY`
  - 기존 `APPLE_CLIENT_ID` 재사용
- DB 변경 없음

## ✅ 테스트

- [x] 서버 실행 확인
- [x] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- Apple access token / refresh token은 별도로 저장하지 않고, 회원탈퇴 시 재인증으로 전달받은 `authorizationCode`를 token으로 교환하여 revoke에 사용
- Apple Private Key는 서버 환경변수로만 관리하며 앱 번들 및 저장소에 포함하지 않음
- 실제 Apple `authorizationCode`를 이용한 token 교환 및 revoke 성공 검증은 Flutter iOS 연동 후 진행 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Apple 로그인 사용자가 회원 탈퇴 시 재인증 코드를 제출하고 Apple 계정 연결을 해제할 수 있습니다.
  * Apple OAuth 토큰 폐기 및 관련 설정을 지원합니다.

* **변경 사항**
  * 회원 탈퇴 요청에 Apple 재인증 코드 입력 항목이 추가되었습니다.
  * Apple 사용자는 유효한 재인증 코드가 없으면 탈퇴를 진행할 수 없습니다.
  * 기존 Kakao 및 Google 회원 탈퇴 동작은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->