### PR TITLE
fix(auth): Refresh Token rotation 동시 요청 제어

### DIFF
--- a/src/main/java/com/chaerok/backend/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/chaerok/backend/auth/repository/RefreshTokenRepository.java
@@ -1,12 +1,26 @@
 package com.chaerok.backend.auth.repository;
 
 import com.chaerok.backend.auth.entity.RefreshToken;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface RefreshTokenRepository
         extends JpaRepository<RefreshToken, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        select rt
+        from RefreshToken rt
+        where rt.tokenHash = :tokenHash
+        """)
+    Optional<RefreshToken> findByTokenHashForUpdate(
+            @Param("tokenHash") String tokenHash
+    );
 
     Optional<RefreshToken> findByTokenHash(String tokenHash);
 

--- a/src/main/java/com/chaerok/backend/auth/service/AuthService.java
+++ b/src/main/java/com/chaerok/backend/auth/service/AuthService.java
@@ -145,7 +145,7 @@ public class AuthService {
                 );
 
         RefreshToken savedToken =
-                refreshTokenService.findValidToken(
+                refreshTokenService.findValidTokenForUpdate(
                         oldRefreshToken
                 );
 

--- a/src/main/java/com/chaerok/backend/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/chaerok/backend/auth/service/RefreshTokenService.java
@@ -56,6 +56,26 @@ public class RefreshTokenService {
         return refreshToken;
     }
 
+    public RefreshToken findValidTokenForUpdate(String rawToken) {
+        String tokenHash = tokenHashUtil.hash(rawToken);
+
+        RefreshToken refreshToken =
+                refreshTokenRepository.findByTokenHashForUpdate(tokenHash)
+                        .orElseThrow(() ->
+                                new InvalidTokenException(
+                                        "저장되지 않았거나 폐기된 Refresh Token입니다."
+                                )
+                        );
+
+        if (refreshToken.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new InvalidTokenException(
+                    "만료된 Refresh Token입니다."
+            );
+        }
+
+        return refreshToken;
+    }
+
     @Transactional
     public void delete(String rawToken) {
         String tokenHash = tokenHashUtil.hash(rawToken);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,9 +70,9 @@ oauth:
 
   apple:
     client-id: ${APPLE_CLIENT_ID}
-    team-id: ${APPLE_TEAM_ID:}
-    key-id: ${APPLE_KEY_ID:}
-    private-key: ${APPLE_PRIVATE_KEY:}
+    team-id: ${APPLE_TEAM_ID}
+    key-id: ${APPLE_KEY_ID}
+    private-key: ${APPLE_PRIVATE_KEY}
     issuer: https://appleid.apple.com
     jwk-set-uri: https://appleid.apple.com/auth/keys
     token-uri: https://appleid.apple.com/auth/token

--- a/src/test/java/com/chaerok/backend/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/chaerok/backend/auth/service/AuthServiceTest.java
@@ -1,0 +1,148 @@
+package com.chaerok.backend.auth.service;
+
+import com.chaerok.backend.auth.dto.RefreshTokenRequest;
+import com.chaerok.backend.auth.entity.RefreshToken;
+import com.chaerok.backend.auth.jwt.JwtTokenProvider;
+import com.chaerok.backend.auth.oauth.verifier.OAuthTokenVerifierResolver;
+import com.chaerok.backend.user.entity.User;
+import com.chaerok.backend.user.entity.UserRole;
+import com.chaerok.backend.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private OAuthTokenVerifierResolver verifierResolver;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private RefreshToken savedToken;
+
+    @Mock
+    private User user;
+
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService(
+                verifierResolver,
+                userService,
+                jwtTokenProvider,
+                refreshTokenService
+        );
+    }
+
+    @Test
+    @DisplayName("refresh는 rotation 전용 락 조회를 사용한다")
+    void refreshUsesLockedRefreshTokenLookup() {
+        // given
+        String oldRefreshToken = "old-refresh-token";
+        String newRefreshToken = "new-refresh-token";
+
+        RefreshTokenRequest request =
+                new RefreshTokenRequest(oldRefreshToken);
+
+        when(jwtTokenProvider.getRefreshTokenUserId(oldRefreshToken))
+                .thenReturn(1L);
+
+        when(refreshTokenService.findValidTokenForUpdate(oldRefreshToken))
+                .thenReturn(savedToken);
+
+        when(savedToken.getUser())
+                .thenReturn(user);
+
+        when(user.getId())
+                .thenReturn(1L);
+
+        when(user.getRole())
+                .thenReturn(UserRole.USER);
+
+        when(jwtTokenProvider.createAccessToken(
+                1L,
+                UserRole.USER
+        )).thenReturn("new-access-token");
+
+        when(jwtTokenProvider.createRefreshToken(1L))
+                .thenReturn(newRefreshToken);
+
+        when(jwtTokenProvider.getExpiration(newRefreshToken))
+                .thenReturn(LocalDateTime.now().plusDays(7));
+
+        // when
+        authService.refresh(request);
+
+        // then
+        verify(refreshTokenService)
+                .findValidTokenForUpdate(oldRefreshToken);
+
+        verify(refreshTokenService, never())
+                .findValidToken(oldRefreshToken);
+
+        verify(refreshTokenService)
+                .delete(oldRefreshToken);
+
+        verify(refreshTokenService)
+                .save(
+                        user,
+                        newRefreshToken,
+                        jwtTokenProvider.getExpiration(newRefreshToken)
+                );
+    }
+
+    @Test
+    @DisplayName("logout은 기존 일반 Refresh Token 조회를 사용한다")
+    void logoutUsesNormalRefreshTokenLookup() {
+        // given
+        String refreshToken = "refresh-token";
+
+        RefreshTokenRequest request =
+                new RefreshTokenRequest(refreshToken);
+
+        when(jwtTokenProvider.getRefreshTokenUserId(refreshToken))
+                .thenReturn(1L);
+
+        when(refreshTokenService.findValidToken(refreshToken))
+                .thenReturn(savedToken);
+
+        when(savedToken.getUser())
+                .thenReturn(user);
+
+        when(user.getId())
+                .thenReturn(1L);
+
+        // when
+        authService.logout(request);
+
+        // then
+        verify(refreshTokenService)
+                .findValidToken(refreshToken);
+
+        verify(refreshTokenService, never())
+                .findValidTokenForUpdate(anyString());
+
+        verify(refreshTokenService)
+                .delete(refreshToken);
+    }
+}

--- a/src/test/java/com/chaerok/backend/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/chaerok/backend/auth/service/RefreshTokenServiceTest.java
@@ -1,0 +1,117 @@
+package com.chaerok.backend.auth.service;
+
+import com.chaerok.backend.auth.entity.RefreshToken;
+import com.chaerok.backend.auth.jwt.TokenHashUtil;
+import com.chaerok.backend.auth.repository.RefreshTokenRepository;
+import com.chaerok.backend.global.exception.InvalidTokenException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private TokenHashUtil tokenHashUtil;
+
+    @Mock
+    private RefreshToken refreshToken;
+
+    private RefreshTokenService refreshTokenService;
+
+    @BeforeEach
+    void setUp() {
+        refreshTokenService = new RefreshTokenService(
+                refreshTokenRepository,
+                tokenHashUtil
+        );
+    }
+
+    @Test
+    @DisplayName("rotation용 조회는 비관적 락 Repository 메서드를 사용한다")
+    void findValidTokenForUpdateUsesLockedQuery() {
+        // given
+        String rawToken = "refresh-token";
+        String tokenHash = "hashed-token";
+
+        when(tokenHashUtil.hash(rawToken))
+                .thenReturn(tokenHash);
+
+        when(refreshTokenRepository.findByTokenHashForUpdate(tokenHash))
+                .thenReturn(Optional.of(refreshToken));
+
+        when(refreshToken.getExpiresAt())
+                .thenReturn(LocalDateTime.now().plusDays(1));
+
+        // when
+        RefreshToken result =
+                refreshTokenService.findValidTokenForUpdate(rawToken);
+
+        // then
+        assertThat(result).isSameAs(refreshToken);
+
+        verify(refreshTokenRepository)
+                .findByTokenHashForUpdate(tokenHash);
+    }
+
+    @Test
+    @DisplayName("rotation용 조회에서 저장되지 않은 Refresh Token이면 예외가 발생한다")
+    void findValidTokenForUpdateRejectsUnknownToken() {
+        // given
+        String rawToken = "refresh-token";
+        String tokenHash = "hashed-token";
+
+        when(tokenHashUtil.hash(rawToken))
+                .thenReturn(tokenHash);
+
+        when(refreshTokenRepository.findByTokenHashForUpdate(tokenHash))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                refreshTokenService.findValidTokenForUpdate(rawToken)
+        )
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessage(
+                        "저장되지 않았거나 폐기된 Refresh Token입니다."
+                );
+    }
+
+    @Test
+    @DisplayName("rotation용 조회에서 만료된 Refresh Token이면 예외가 발생한다")
+    void findValidTokenForUpdateRejectsExpiredToken() {
+        // given
+        String rawToken = "refresh-token";
+        String tokenHash = "hashed-token";
+
+        when(tokenHashUtil.hash(rawToken))
+                .thenReturn(tokenHash);
+
+        when(refreshTokenRepository.findByTokenHashForUpdate(tokenHash))
+                .thenReturn(Optional.of(refreshToken));
+
+        when(refreshToken.getExpiresAt())
+                .thenReturn(LocalDateTime.now().minusMinutes(1));
+
+        // when & then
+        assertThatThrownBy(() ->
+                refreshTokenService.findValidTokenForUpdate(rawToken)
+        )
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessage("만료된 Refresh Token입니다.");
+    }
+}


### PR DESCRIPTION
## ✨ 변경 사항

- Refresh Token rotation 시 기존 토큰 조회에 비관적 락 적용
- `/refresh`에서 rotation 전용 `findByTokenHashForUpdate()` 조회 사용
- logout 등 기존 일반 Refresh Token 조회 흐름 유지
- Refresh Token rotation 관련 단위 테스트 추가
- Apple 설정값 형식 수정

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [x] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #84 

## 🧩 API / DB 변경 사항

- API 요청/응답 구조 변경 없음
- DB 스키마 변경 없음

## ✅ 테스트

- [x] 서버 실행 확인
- [ ] Swagger 확인
- [ ] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- 동일 Refresh Token 동시 rotation 시 기존 토큰 row에 `PESSIMISTIC_WRITE` 락을 적용하도록 개선
- `/refresh`에서만 락 조회를 사용하고 logout은 기존 일반 조회 방식 유지
- `RefreshTokenServiceTest`, `AuthServiceTest` 통과
- 전체 테스트 및 빌드 통과
- 실제 PostgreSQL 동시 요청 통합 테스트는 Testcontainers 기반 테스트 환경 도입 시 추가 검증 예정
- Apple 설정값 형식 수정 포함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * Refresh Token 갱신 과정의 동시 요청 처리를 개선해 토큰 회전이 안전하게 수행됩니다.
  * 유효하지 않거나 만료된 Refresh Token에 대한 검증이 강화되었습니다.

* **설정**
  * Apple OAuth 필수 환경 변수가 누락되면 애플리케이션이 시작되지 않도록 변경되었습니다.

* **테스트**
  * Refresh Token 갱신 및 로그아웃 동작과 예외 처리에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->