### PR TITLE
fix(heritage): TourAPI 실패 시 DB fallback 적용

### DIFF
--- a/src/main/java/com/chaerok/backend/heritage/dto/HeritagePlaceResponse.java
+++ b/src/main/java/com/chaerok/backend/heritage/dto/HeritagePlaceResponse.java
@@ -1,5 +1,6 @@
 package com.chaerok.backend.heritage.dto;
 
+import com.chaerok.backend.place.entity.Place;
 import com.chaerok.backend.place.external.TourApiPlaceItem;
 
 public record HeritagePlaceResponse(
@@ -34,6 +35,26 @@ public record HeritagePlaceResponse(
                 item.lclsSystm3(),
                 item.overview(),
                 item.firstImageUrl()
+        );
+    }
+
+    public static HeritagePlaceResponse fromPlace(
+            Place place,
+            String regionName,
+            boolean heritage
+    ) {
+        return new HeritagePlaceResponse(
+                place.getId(),
+                place.getTourContentId(),
+                place.getTitle(),
+                place.getAddress(),
+                regionName,
+                heritage,
+                place.getLclsSystm1(),
+                place.getLclsSystm2(),
+                place.getLclsSystm3(),
+                null,
+                place.getFirstImageUrl()
         );
     }
 }

--- a/src/main/java/com/chaerok/backend/heritage/service/HeritageService.java
+++ b/src/main/java/com/chaerok/backend/heritage/service/HeritageService.java
@@ -2,6 +2,7 @@ package com.chaerok.backend.heritage.service;
 
 import com.chaerok.backend.heritage.dto.HeritagePlaceResponse;
 import com.chaerok.backend.place.entity.Place;
+import com.chaerok.backend.place.entity.PlaceCategoryDetail;
 import com.chaerok.backend.place.external.TourApiPlaceClient;
 import com.chaerok.backend.place.external.TourApiPlaceItem;
 import com.chaerok.backend.place.repository.PlaceRepository;
@@ -29,23 +30,37 @@ public class HeritageService {
             throw new IllegalArgumentException("TourAPI 장소가 아닙니다.");
         }
 
-        TourApiPlaceItem item = tourApiPlaceClient.getPlaceDetail(contentId);
-
-        if (item == null) {
-            throw new IllegalStateException("TourAPI 장소 정보를 조회할 수 없습니다.");
-        }
-
-        boolean heritage = isHeritage(item);
-
         String regionName = place.getRegion().getProvinceName()
                 + " "
                 + place.getRegion().getCityCountyName();
+
+        TourApiPlaceItem item = tourApiPlaceClient.getPlaceDetail(contentId);
+
+        if (item == null) {
+            return createFallbackResponse(place, regionName);
+        }
+
+        boolean heritage = isHeritage(item);
 
         return HeritagePlaceResponse.of(
                 place.getId(),
                 regionName,
                 heritage,
                 item
+        );
+    }
+
+    private HeritagePlaceResponse createFallbackResponse(
+            Place place,
+            String regionName
+    ) {
+        boolean heritage =
+                place.getCategoryDetail() == PlaceCategoryDetail.HERITAGE;
+
+        return HeritagePlaceResponse.fromPlace(
+                place,
+                regionName,
+                heritage
         );
     }
 

--- a/src/test/java/com/chaerok/backend/heritage/service/HeritageServiceTest.java
+++ b/src/test/java/com/chaerok/backend/heritage/service/HeritageServiceTest.java
@@ -1,0 +1,202 @@
+package com.chaerok.backend.heritage.service;
+
+import com.chaerok.backend.heritage.dto.HeritagePlaceResponse;
+import com.chaerok.backend.place.entity.Place;
+import com.chaerok.backend.place.entity.PlaceCategoryDetail;
+import com.chaerok.backend.place.external.TourApiPlaceClient;
+import com.chaerok.backend.place.external.TourApiPlaceItem;
+import com.chaerok.backend.place.repository.PlaceRepository;
+import com.chaerok.backend.region.entity.Region;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HeritageServiceTest {
+
+    @Mock
+    private PlaceRepository placeRepository;
+
+    @Mock
+    private TourApiPlaceClient tourApiPlaceClient;
+
+    @Mock
+    private Place place;
+
+    @Mock
+    private Region region;
+
+    private HeritageService heritageService;
+
+    @BeforeEach
+    void setUp() {
+        heritageService = new HeritageService(
+                placeRepository,
+                tourApiPlaceClient
+        );
+    }
+
+    @Test
+    void TourAPI_유적지_분류이면_유적지로_판별한다() {
+        // given
+        Long placeId = 1L;
+        String contentId = "100";
+
+        givenPlace(placeId, contentId);
+
+        TourApiPlaceItem item = createTourApiItem(
+                contentId,
+                "HS"
+        );
+
+        when(tourApiPlaceClient.getPlaceDetail(contentId))
+                .thenReturn(item);
+
+        // when
+        HeritagePlaceResponse response =
+                heritageService.getHeritagePlace(placeId);
+
+        // then
+        assertThat(response.heritage()).isTrue();
+    }
+
+    @Test
+    void TourAPI_유적지_분류가_아니면_일반_장소로_판별한다() {
+        // given
+        Long placeId = 1L;
+        String contentId = "100";
+
+        givenPlace(placeId, contentId);
+
+        TourApiPlaceItem item = createTourApiItem(
+                contentId,
+                "EX"
+        );
+
+        when(tourApiPlaceClient.getPlaceDetail(contentId))
+                .thenReturn(item);
+
+        // when
+        HeritagePlaceResponse response =
+                heritageService.getHeritagePlace(placeId);
+
+        // then
+        assertThat(response.heritage()).isFalse();
+    }
+
+    @Test
+    void 궁남지는_TourAPI_분류와_관계없이_유적지로_판별한다() {
+        // given
+        Long placeId = 1L;
+        String contentId = "125984";
+
+        givenPlace(placeId, contentId);
+
+        TourApiPlaceItem item = createTourApiItem(
+                contentId,
+                "EX"
+        );
+
+        when(tourApiPlaceClient.getPlaceDetail(contentId))
+                .thenReturn(item);
+
+        // when
+        HeritagePlaceResponse response =
+                heritageService.getHeritagePlace(placeId);
+
+        // then
+        assertThat(response.heritage()).isTrue();
+    }
+
+    @Test
+    void TourAPI_조회_실패시_DB가_HERITAGE이면_유적지로_fallback한다() {
+        // given
+        Long placeId = 1L;
+        String contentId = "100";
+
+        givenPlace(placeId, contentId);
+
+        when(place.getCategoryDetail())
+                .thenReturn(PlaceCategoryDetail.HERITAGE);
+        when(place.getTitle()).thenReturn("공산성");
+        when(place.getAddress()).thenReturn("충남 공주시");
+
+        when(tourApiPlaceClient.getPlaceDetail(contentId))
+                .thenReturn(null);
+
+        // when
+        HeritagePlaceResponse response =
+                heritageService.getHeritagePlace(placeId);
+
+        // then
+        assertThat(response.heritage()).isTrue();
+        assertThat(response.placeId()).isEqualTo(placeId);
+        assertThat(response.contentId()).isEqualTo(contentId);
+        assertThat(response.title()).isEqualTo("공산성");
+        assertThat(response.address()).isEqualTo("충남 공주시");
+    }
+
+    @Test
+    void TourAPI_조회_실패시_DB가_HERITAGE가_아니면_일반_장소로_fallback한다() {
+        // given
+        Long placeId = 1L;
+        String contentId = "100";
+
+        givenPlace(placeId, contentId);
+
+        when(place.getCategoryDetail())
+                .thenReturn(PlaceCategoryDetail.WALK);
+
+        when(tourApiPlaceClient.getPlaceDetail(contentId))
+                .thenReturn(null);
+
+        // when
+        HeritagePlaceResponse response =
+                heritageService.getHeritagePlace(placeId);
+
+        // then
+        assertThat(response.heritage()).isFalse();
+    }
+
+    private void givenPlace(
+            Long placeId,
+            String contentId
+    ) {
+        when(placeRepository.findById(placeId))
+                .thenReturn(Optional.of(place));
+
+        when(place.getId()).thenReturn(placeId);
+        when(place.getTourContentId()).thenReturn(contentId);
+        when(place.getRegion()).thenReturn(region);
+
+        when(region.getProvinceName()).thenReturn("충청남도");
+        when(region.getCityCountyName()).thenReturn("공주시");
+    }
+
+    private TourApiPlaceItem createTourApiItem(
+            String contentId,
+            String lclsSystm1
+    ) {
+        return new TourApiPlaceItem(
+                contentId,
+                "공산성",
+                "충남 공주시",
+                null,
+                null,
+                null,
+                null,
+                null,
+                lclsSystm1,
+                null,
+                null,
+                null
+        );
+    }
+}


### PR DESCRIPTION
## ✨ 변경 사항

- TourAPI 장소 상세 조회 실패 시 Place DB 기반 fallback 처리
- DB `categoryDetail`을 활용한 유적지 여부 판별 추가
- TourAPI 응답 없이도 Place DB 정보로 Heritage 응답 생성 가능하도록 개선
- 기존 TourAPI 정상 응답 및 궁남지 예외 처리 흐름 유지
- Heritage 정상/실패/fallback 케이스 단위 테스트 추가

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #86 

## 🧩 API / DB 변경 사항

- 없음

## ✅ 테스트

- [x] 서버 실행 확인
- [ ] Swagger 확인
- [ ] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- TourAPI 정상 응답 시 기존 TourAPI 분류 기준을 우선 사용
- TourAPI 조회 실패 시 Place DB의 관광 분류 및 장소 정보를 fallback으로 사용
- 기존 궁남지 contentId 기반 유적지 예외 처리 유지
- 전체 테스트 및 빌드 통과