### PR TITLE
fix(exception): 내부 IllegalArgumentException 응답 처리 수정

### DIFF
--- a/src/main/java/com/chaerok/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chaerok/backend/global/exception/GlobalExceptionHandler.java
@@ -179,20 +179,6 @@ public class GlobalExceptionHandler {
                 ));
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalArgument(
-            IllegalArgumentException exception,
-            HttpServletRequest request
-    ) {
-        return ResponseEntity
-                .badRequest()
-                .body(ErrorResponse.of(
-                        "BAD_REQUEST",
-                        exception.getMessage(),
-                        request.getRequestURI()
-                ));
-    }
-
     @ExceptionHandler(ObjectStorageException.class)
     public ResponseEntity<ErrorResponse> handleObjectStorage(
             ObjectStorageException exception,

--- a/src/test/java/com/chaerok/backend/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/chaerok/backend/global/exception/GlobalExceptionHandlerTest.java
@@ -7,6 +7,7 @@ import jakarta.validation.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
@@ -240,5 +241,26 @@ class GlobalExceptionHandlerTest {
                 .isEqualTo("서버 내부 오류가 발생했습니다.");
         assertThat(response.getBody().path())
                 .isEqualTo("/api/test");
+    }
+
+    @Test
+    @DisplayName("처리되지 않은 IllegalArgumentException은 서버 내부 오류로 처리한다")
+    void handleIllegalArgumentAsInternalServerError() {
+        IllegalArgumentException exception =
+                new IllegalArgumentException("internal validation failure");
+
+        ResponseEntity<ErrorResponse> response =
+                handler.handleException(
+                        exception,
+                        request
+                );
+
+        assertThat(response.getStatusCode())
+                .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().code())
+                .isEqualTo(CommonErrorCode.INTERNAL_SERVER_ERROR.getCode());
+        assertThat(response.getBody().message())
+                .isEqualTo(CommonErrorCode.INTERNAL_SERVER_ERROR.getMessage());
     }
 }


### PR DESCRIPTION
## ✨ 변경 사항

- `GlobalExceptionHandler`의 `IllegalArgumentException` 전용 400 응답 처리 제거
- 내부 불변식 및 메서드 계약 검증 과정에서 발생한 `IllegalArgumentException`이 공통 예외 fallback을 통해 `500 INTERNAL_SERVER_ERROR`로 처리되도록 수정
- 내부 예외 메시지가 클라이언트 응답에 직접 노출되지 않도록 처리
- `IllegalArgumentException`의 `COMMON_500` 응답 처리를 검증하는 테스트 추가

## 📌 담당 영역

- [x] 공통 설정 / 인프라
- [ ] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #92 

## 🧩 API / DB 변경 사항

- API 엔드포인트 변경 없음
- DB 변경 없음
- 내부 `IllegalArgumentException` 발생 시 기존 `400 BAD_REQUEST` 대신 `500 COMMON_500` 응답 반환

## ✅ 테스트

- [x] 서버 실행 확인
- [ ] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- 사용자 요청 검증은 기존 요청 검증 예외 handler에서 400 응답으로 처리
- 도메인 비즈니스 예외는 기존 `BusinessException`과 각 도메인 `ErrorCode` 기반 처리 유지
- 내부 불변식 및 메서드 계약 검증용 `IllegalArgumentException`만 일반 예외 fallback을 통해 `COMMON_500`으로 처리
- 관련 테스트 및 전체 테스트 통과 확인