### PR TITLE
fix(course): 코스 3분류 구성 보장

### DIFF
--- a/src/main/java/com/chaerok/backend/course/exception/CourseErrorCode.java
+++ b/src/main/java/com/chaerok/backend/course/exception/CourseErrorCode.java
@@ -97,6 +97,18 @@ public enum CourseErrorCode implements ErrorCode {
             HttpStatus.NOT_FOUND,
             "COURSE_015",
             "ACTIVE 코스가 없습니다."
+    ),
+
+    INVALID_ANCHOR_CATEGORY(
+            HttpStatus.BAD_REQUEST,
+            "COURSE_016",
+            "추천 코스의 앵커 장소는 관광지 유형이어야 합니다."
+    ),
+
+    INVALID_COURSE_CATEGORY_COMPOSITION(
+            HttpStatus.BAD_REQUEST,
+            "COURSE_017",
+            "코스는 관광지, 음식점, 카페/디저트 각 1곳으로 구성해야 합니다."
     );
 
     private final HttpStatus status;

--- a/src/main/java/com/chaerok/backend/course/service/CoursePersistenceService.java
+++ b/src/main/java/com/chaerok/backend/course/service/CoursePersistenceService.java
@@ -33,6 +33,12 @@ import java.util.Set;
 public class CoursePersistenceService {
 
     private static final int MAX_COURSE_PLACE_COUNT = 3;
+    private static final Set<PlaceCategoryGroup> REQUIRED_COURSE_CATEGORIES =
+            Set.of(
+                    PlaceCategoryGroup.TOURISM,
+                    PlaceCategoryGroup.FOOD,
+                    PlaceCategoryGroup.CAFE_DESSERT
+            );
 
     private final CourseRepository courseRepository;
     private final CoursePlaceRepository coursePlaceRepository;
@@ -62,20 +68,33 @@ public class CoursePersistenceService {
             Region region,
             List<ResolvedCoursePlace> resolvedPlaces
     ) {
-        int currentPlaceCount = coursePlaceRepository.countByCourseId(
-                course.getId()
-        );
-
-        if (currentPlaceCount + resolvedPlaces.size()
-                > MAX_COURSE_PLACE_COUNT) {
-            throw new BusinessException(
-                    CourseErrorCode.COURSE_PLACE_LIMIT_EXCEEDED
-            );
-        }
-
         addPlaces(course, region, resolvedPlaces);
 
         return getCourseResponse(course);
+    }
+
+    private void validateFinalCourseCategories(
+            Course course,
+            List<Place> newPlaces
+    ) {
+        Set<PlaceCategoryGroup> categoryGroups =
+                new HashSet<>(coursePlaceRepository
+                        .findByCourseIdOrderBySequenceAsc(course.getId())
+                        .stream()
+                        .map(coursePlace ->
+                                coursePlace.getPlace().getCategoryGroup()
+                        )
+                        .toList());
+
+        newPlaces.stream()
+                .map(Place::getCategoryGroup)
+                .forEach(categoryGroups::add);
+
+        if (!categoryGroups.equals(REQUIRED_COURSE_CATEGORIES)) {
+            throw new BusinessException(
+                    CourseErrorCode.INVALID_COURSE_CATEGORY_COMPOSITION
+            );
+        }
     }
 
     private void inactiveActiveCourses(Long userId) {
@@ -93,15 +112,31 @@ public class CoursePersistenceService {
             Region region,
             List<ResolvedCoursePlace> resolvedPlaces
     ) {
-        validateDuplicateCategoryInRequest(resolvedPlaces);
-
-        int nextSequence = coursePlaceRepository.countByCourseId(
+        int currentPlaceCount = coursePlaceRepository.countByCourseId(
                 course.getId()
-        ) + 1;
+        );
 
-        for (ResolvedCoursePlace resolvedPlace : resolvedPlaces) {
-            Place place = resolvePlace(region, resolvedPlace);
+        int finalPlaceCount = currentPlaceCount + resolvedPlaces.size();
 
+        if (finalPlaceCount > MAX_COURSE_PLACE_COUNT) {
+            throw new BusinessException(
+                    CourseErrorCode.COURSE_PLACE_LIMIT_EXCEEDED
+            );
+        }
+
+        List<Place> places = resolvedPlaces.stream()
+                .map(resolvedPlace -> resolvePlace(region, resolvedPlace))
+                .toList();
+
+        validateDuplicateCategoryInPlaces(places);
+
+        if (finalPlaceCount == MAX_COURSE_PLACE_COUNT) {
+            validateFinalCourseCategories(course, places);
+        }
+
+        int nextSequence = currentPlaceCount + 1;
+
+        for (Place place : places) {
             validateCoursePlace(course, place);
 
             CoursePlace coursePlace = CoursePlace.create(
@@ -403,19 +438,13 @@ public class CoursePersistenceService {
         }
     }
 
-    private void validateDuplicateCategoryInRequest(
-            List<ResolvedCoursePlace> resolvedPlaces
+    private void validateDuplicateCategoryInPlaces(
+            List<Place> places
     ) {
         Set<PlaceCategoryGroup> categoryGroups = new HashSet<>();
 
-        for (ResolvedCoursePlace resolvedPlace : resolvedPlaces) {
-            CoursePlaceSaveRequest request =
-                    resolvedPlace.request();
-
-            PlaceCategoryGroup categoryGroup =
-                    toCategoryGroup(request.categoryGroup());
-
-            if (!categoryGroups.add(categoryGroup)) {
+        for (Place place : places) {
+            if (!categoryGroups.add(place.getCategoryGroup())) {
                 throw new BusinessException(
                         CourseErrorCode.DUPLICATE_REQUEST_PLACE_CATEGORY
                 );

--- a/src/main/java/com/chaerok/backend/course/service/CourseRecommendService.java
+++ b/src/main/java/com/chaerok/backend/course/service/CourseRecommendService.java
@@ -56,21 +56,33 @@ public class CourseRecommendService {
         if (anchorPlaceId != null) {
             Place anchor = findAnchor(regionId, anchorPlaceId);
 
+            CourseResponse course = createCourse(anchor, representativePlaces);
+
             return new CourseRecommendResponse(
                     regionId,
                     RECOMMENDATION_TYPE_ANCHOR,
                     anchor.getId(),
-                    List.of(createCourse(anchor, representativePlaces))
+                    isCompleteCourse(course) ? List.of(course) : List.of()
             );
         }
 
         List<Place> anchors = findRegionAnchors(representativePlaces);
 
-        List<CourseResponse> courses = anchors.stream()
-                .map(anchor -> createCourse(anchor, representativePlaces))
+        List<AnchorCourse> validCourses = anchors.stream()
+                .map(anchor -> new AnchorCourse(
+                        anchor,
+                        createCourse(anchor, representativePlaces)
+                ))
+                .filter(anchorCourse -> isCompleteCourse(anchorCourse.course()))
                 .toList();
 
-        Long firstAnchorPlaceId = anchors.isEmpty() ? null : anchors.get(0).getId();
+        List<CourseResponse> courses = validCourses.stream()
+                .map(AnchorCourse::course)
+                .toList();
+
+        Long firstAnchorPlaceId = validCourses.isEmpty()
+                ? null
+                : validCourses.get(0).anchor().getId();
 
         return new CourseRecommendResponse(
                 regionId,
@@ -78,6 +90,13 @@ public class CourseRecommendService {
                 firstAnchorPlaceId,
                 courses
         );
+    }
+
+    private boolean isCompleteCourse(CourseResponse course) {
+        return course.places().size() == MAX_COURSE_PLACE_COUNT
+                && containsCategoryGroup(course.places(), PlaceCategoryGroup.TOURISM)
+                && containsCategoryGroup(course.places(), PlaceCategoryGroup.FOOD)
+                && containsCategoryGroup(course.places(), PlaceCategoryGroup.CAFE_DESSERT);
     }
 
     private void validateRegion(Long regionId) {
@@ -111,6 +130,12 @@ public class CourseRecommendService {
             );
         }
 
+        if (anchor.getCategoryGroup() != PlaceCategoryGroup.TOURISM) {
+            throw new BusinessException(
+                    CourseErrorCode.INVALID_ANCHOR_CATEGORY
+            );
+        }
+
         if (!hasCoordinate(anchor)) {
             throw new BusinessException(
                     CourseErrorCode.ANCHOR_COORDINATE_MISSING
@@ -141,15 +166,21 @@ public class CourseRecommendService {
 
         findFirstFoodCandidate(anchor)
                 .map(CoursePlaceResponse::fromKakaoFood)
+                .or(() -> findFallbackPlace(
+                        anchor,
+                        representativePlaces,
+                        PlaceCategoryGroup.FOOD
+                ).map(CoursePlaceResponse::fromPlace))
                 .ifPresent(places::add);
 
         findFirstCafeCandidate(anchor)
                 .map(CoursePlaceResponse::fromKakaoCafe)
+                .or(() -> findFallbackPlace(
+                        anchor,
+                        representativePlaces,
+                        PlaceCategoryGroup.CAFE_DESSERT
+                ).map(CoursePlaceResponse::fromPlace))
                 .ifPresent(places::add);
-
-        if (places.size() < MAX_COURSE_PLACE_COUNT) {
-            addFallbackPlaces(anchor, representativePlaces, places);
-        }
 
         return new CourseResponse(
                 createCourseTitle(anchor),
@@ -220,33 +251,18 @@ public class CourseRecommendService {
                 && candidate.addressName().contains(cityCountyName);
     }
 
-    private void addFallbackPlaces(
+    private java.util.Optional<Place> findFallbackPlace(
             Place anchor,
             List<Place> representativePlaces,
-            List<CoursePlaceResponse> places
+            PlaceCategoryGroup categoryGroup
     ) {
-        List<Place> fallbackPlaces = representativePlaces.stream()
+        return representativePlaces.stream()
                 .filter(this::hasCoordinate)
                 .filter(place -> !place.getId().equals(anchor.getId()))
-                .filter(place -> !containsPlace(places, place.getId()))
-                .sorted(Comparator.comparingDouble(place -> calculateDistanceMeters(anchor, place)))
-                .toList();
-
-        for (Place fallbackPlace : fallbackPlaces) {
-            if (places.size() >= MAX_COURSE_PLACE_COUNT) {
-                return;
-            }
-
-            places.add(CoursePlaceResponse.fromPlace(fallbackPlace));
-        }
-    }
-
-    private boolean containsPlace(
-            List<CoursePlaceResponse> places,
-            Long placeId
-    ) {
-        return places.stream()
-                .anyMatch(place -> placeId.equals(place.placeId()));
+                .filter(place -> place.getCategoryGroup() == categoryGroup)
+                .min(Comparator.comparingDouble(
+                        place -> calculateDistanceMeters(anchor, place)
+                ));
     }
 
     private String createCourseTitle(Place anchor) {
@@ -348,5 +364,11 @@ public class CourseRecommendService {
         double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 
         return earthRadiusMeters * c;
+    }
+
+    private record AnchorCourse(
+            Place anchor,
+            CourseResponse course
+    ) {
     }
 }

--- a/src/test/java/com/chaerok/backend/course/service/CoursePersistenceServiceTest.java
+++ b/src/test/java/com/chaerok/backend/course/service/CoursePersistenceServiceTest.java
@@ -515,6 +515,153 @@ class CoursePersistenceServiceTest {
                 .isEqualTo(PlaceSource.TOUR_API);
     }
 
+    @Test
+    @DisplayName("최종 3곳의 유형 구성이 올바르지 않으면 저장하지 않는다")
+    void addPlacesRejectsInvalidFinalCategoryComposition() {
+        // given
+        when(course.getId()).thenReturn(COURSE_ID);
+        when(region.getId()).thenReturn(REGION_ID);
+
+        Place existingTourism = org.mockito.Mockito.mock(Place.class);
+        when(existingTourism.getCategoryGroup())
+                .thenReturn(PlaceCategoryGroup.TOURISM);
+
+        CoursePlace existingCoursePlace =
+                org.mockito.Mockito.mock(CoursePlace.class);
+
+        when(existingCoursePlace.getPlace())
+                .thenReturn(existingTourism);
+
+        Place food = org.mockito.Mockito.mock(Place.class);
+        when(food.getRegion()).thenReturn(region);
+        when(food.getCategoryGroup())
+                .thenReturn(PlaceCategoryGroup.FOOD);
+
+        Place anotherTourism = org.mockito.Mockito.mock(Place.class);
+        when(anotherTourism.getRegion()).thenReturn(region);
+        when(anotherTourism.getCategoryGroup())
+                .thenReturn(PlaceCategoryGroup.TOURISM);
+
+        when(coursePlaceRepository.countByCourseId(COURSE_ID))
+                .thenReturn(1);
+
+        when(coursePlaceRepository
+                .findByCourseIdOrderBySequenceAsc(COURSE_ID))
+                .thenReturn(List.of(existingCoursePlace));
+
+        when(placeRepository.findById(2L))
+                .thenReturn(Optional.of(food));
+        when(placeRepository.findById(3L))
+                .thenReturn(Optional.of(anotherTourism));
+
+        // when & then
+        assertThatThrownBy(() ->
+                persistenceService.addPlacesToCourse(
+                        course,
+                        region,
+                        List.of(
+                                resolvedPlace(2L, "FOOD"),
+                                resolvedPlace(3L, "CAFE_DESSERT")
+                        )
+                )
+        )
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException businessException =
+                            (BusinessException) exception;
+
+                    assertThat(businessException.getErrorCode())
+                            .isEqualTo(
+                                    CourseErrorCode.INVALID_COURSE_CATEGORY_COMPOSITION
+                            );
+                });
+
+        verify(coursePlaceRepository, never())
+                .save(any(CoursePlace.class));
+    }
+
+    @Test
+    @DisplayName("코스 장소가 3곳을 초과하면 장소 조회 전에 요청을 거부한다")
+    void addPlacesRejectsOverLimitBeforeResolvingPlace() {
+        // given
+        when(course.getId()).thenReturn(COURSE_ID);
+
+        when(coursePlaceRepository.countByCourseId(COURSE_ID))
+                .thenReturn(3);
+
+        // when & then
+        assertThatThrownBy(() ->
+                persistenceService.addPlacesToCourse(
+                        course,
+                        region,
+                        List.of(
+                                resolvedPlace(4L, "FOOD")
+                        )
+                )
+        )
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException businessException =
+                            (BusinessException) exception;
+
+                    assertThat(businessException.getErrorCode())
+                            .isEqualTo(
+                                    CourseErrorCode.COURSE_PLACE_LIMIT_EXCEEDED
+                            );
+                });
+
+        verify(placeRepository, never())
+                .findById(any());
+    }
+
+    @Test
+    @DisplayName("코스가 3곳이 되면 관광지 음식점 카페 각 1곳으로 저장할 수 있다")
+    void addPlacesAllowsRequiredThreeCategories() {
+        // given
+        mockSuccessfulCourse();
+
+        Place tourism = createPlace(
+                1L,
+                PlaceCategoryGroup.TOURISM
+        );
+
+        Place food = createPlace(
+                2L,
+                PlaceCategoryGroup.FOOD
+        );
+
+        Place cafe = createPlace(
+                3L,
+                PlaceCategoryGroup.CAFE_DESSERT
+        );
+
+        when(coursePlaceRepository.countByCourseId(COURSE_ID))
+                .thenReturn(0);
+
+        when(placeRepository.findById(1L))
+                .thenReturn(Optional.of(tourism));
+        when(placeRepository.findById(2L))
+                .thenReturn(Optional.of(food));
+        when(placeRepository.findById(3L))
+                .thenReturn(Optional.of(cafe));
+
+        // when
+        persistenceService.addPlacesToCourse(
+                course,
+                region,
+                List.of(
+                        resolvedPlace(1L, "TOURISM"),
+                        resolvedPlace(2L, "FOOD"),
+                        resolvedPlace(3L, "CAFE_DESSERT")
+                )
+        );
+
+        // then
+        verify(coursePlaceRepository,
+                org.mockito.Mockito.times(3))
+                .save(any(CoursePlace.class));
+    }
+
     private void mockSuccessfulCourse() {
         when(course.getId())
                 .thenReturn(COURSE_ID);
@@ -589,5 +736,39 @@ class CoursePersistenceServiceTest {
                 "HS01",
                 null
         );
+    }
+
+    private Place createPlace(
+            Long id,
+            PlaceCategoryGroup categoryGroup
+    ) {
+        Place place = org.mockito.Mockito.mock(Place.class);
+
+        when(place.getId()).thenReturn(id);
+        when(place.getRegion()).thenReturn(region);
+        when(place.getCategoryGroup()).thenReturn(categoryGroup);
+
+        return place;
+    }
+
+    private ResolvedCoursePlace resolvedPlace(
+            Long placeId,
+            String categoryGroup
+    ) {
+        CoursePlaceSaveRequest request =
+                new CoursePlaceSaveRequest(
+                        placeId,
+                        null,
+                        PlaceSource.TOUR_API.name(),
+                        "테스트 장소",
+                        categoryGroup,
+                        null,
+                        "충남 공주시",
+                        null,
+                        null,
+                        null
+                );
+
+        return ResolvedCoursePlace.of(request, null);
     }
 }

--- a/src/test/java/com/chaerok/backend/course/service/CourseRecommendServiceTest.java
+++ b/src/test/java/com/chaerok/backend/course/service/CourseRecommendServiceTest.java
@@ -2,6 +2,7 @@ package com.chaerok.backend.course.service;
 
 import com.chaerok.backend.course.dto.CoursePlaceResponse;
 import com.chaerok.backend.course.dto.CourseRecommendResponse;
+import com.chaerok.backend.global.exception.BusinessException;
 import com.chaerok.backend.place.entity.Place;
 import com.chaerok.backend.place.entity.PlaceCategoryDetail;
 import com.chaerok.backend.place.entity.PlaceCategoryGroup;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -85,7 +87,7 @@ class CourseRecommendServiceTest {
                 2000
         )).thenReturn(List.of(food));
 
-        mockEmptyCafeSearch();
+        mockDefaultCafeSearch();
 
         // when
         CourseRecommendResponse response =
@@ -145,7 +147,7 @@ class CourseRecommendServiceTest {
                 5000
         )).thenReturn(List.of(expandedFood));
 
-        mockEmptyCafeSearch();
+        mockDefaultCafeSearch();
 
         // when
         CourseRecommendResponse response =
@@ -216,7 +218,7 @@ class CourseRecommendServiceTest {
                 sameRegionExpanded
         ));
 
-        mockEmptyCafeSearch();
+        mockDefaultCafeSearch();
 
         // when
         CourseRecommendResponse response =
@@ -239,8 +241,8 @@ class CourseRecommendServiceTest {
     }
 
     @Test
-    @DisplayName("기본 및 확장 반경에 다른 시군 음식점만 있으면 음식점을 추천하지 않는다")
-    void recommendDoesNotUseOutsideRegionCandidate() {
+    @DisplayName("음식점 후보와 fallback이 모두 없으면 불완전한 코스를 추천하지 않는다")
+    void recommendExcludesIncompleteCourseWhenFoodIsUnavailable() {
         // given
         mockAnchor();
 
@@ -272,7 +274,7 @@ class CourseRecommendServiceTest {
                 5000
         )).thenReturn(List.of(outsideExpanded));
 
-        mockEmptyCafeSearch();
+        mockDefaultCafeSearch();
 
         // when
         CourseRecommendResponse response =
@@ -282,21 +284,308 @@ class CourseRecommendServiceTest {
                 );
 
         // then
-        List<CoursePlaceResponse> places =
-                response.courses().get(0).places();
+        assertThat(response.courses()).isEmpty();
+    }
 
-        assertThat(places)
-                .noneMatch(place ->
-                        PlaceCategoryGroup.FOOD.name()
-                                .equals(place.categoryGroup())
+    @Test
+    @DisplayName("카카오 음식점 후보가 없으면 같은 유형의 DB 대표 장소를 fallback으로 사용한다")
+    void recommendUsesFoodFallbackFromDatabase() {
+        // given
+        mockAnchor();
+
+        Place foodFallback = mockPlace(
+                20L,
+                "공주 DB 식당",
+                PlaceCategoryGroup.FOOD,
+                PlaceCategoryDetail.RESTAURANT,
+                "36.4510",
+                "127.1210"
+        );
+
+        when(placeRepository.findByRegionIdAndRepresentativeTrue(REGION_ID))
+                .thenReturn(List.of(anchor, foodFallback));
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "FD6",
+                ANCHOR_LONGITUDE,
+                ANCHOR_LATITUDE,
+                2000
+        )).thenReturn(List.of());
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "FD6",
+                ANCHOR_LONGITUDE,
+                ANCHOR_LATITUDE,
+                5000
+        )).thenReturn(List.of());
+
+        mockDefaultCafeSearch();
+
+        // when
+        CourseRecommendResponse response =
+                courseRecommendService.recommendCourses(
+                        REGION_ID,
+                        ANCHOR_ID
                 );
 
-        assertThat(places)
+        // then
+        assertThat(response.courses())
+                .hasSize(1);
+
+        assertThat(response.courses().get(0).places())
                 .extracting(CoursePlaceResponse::title)
-                .doesNotContain(
-                        "논산 식당 1",
-                        "논산 식당 2"
+                .contains("공주 DB 식당");
+    }
+
+    private Place mockPlace(
+            Long id,
+            String title,
+            PlaceCategoryGroup categoryGroup,
+            PlaceCategoryDetail categoryDetail,
+            String latitude,
+            String longitude
+    ) {
+        Place place = org.mockito.Mockito.mock(Place.class);
+
+        when(place.getId()).thenReturn(id);
+        when(place.getTitle()).thenReturn(title);
+        when(place.getAddress()).thenReturn("충남 공주시");
+        when(place.getLatitude()).thenReturn(new BigDecimal(latitude));
+        when(place.getLongitude()).thenReturn(new BigDecimal(longitude));
+        when(place.getCategoryGroup()).thenReturn(categoryGroup);
+        when(place.getCategoryDetail()).thenReturn(categoryDetail);
+        when(place.getSource()).thenReturn(PlaceSource.TOUR_API);
+
+        return place;
+    }
+
+    @Test
+    @DisplayName("카카오 카페 후보가 없으면 같은 유형의 DB 대표 장소를 fallback으로 사용한다")
+    void recommendUsesCafeFallbackFromDatabase() {
+        // given
+        mockAnchor();
+
+        Place cafeFallback = mockPlace(
+                30L,
+                "공주 DB 카페",
+                PlaceCategoryGroup.CAFE_DESSERT,
+                PlaceCategoryDetail.CAFE,
+                "36.4520",
+                "127.1220"
+        );
+
+        when(placeRepository.findByRegionIdAndRepresentativeTrue(REGION_ID))
+                .thenReturn(List.of(anchor, cafeFallback));
+
+        KakaoPlaceItem food = createKakaoPlace(
+                "food-1",
+                "공주 식당",
+                "FD6",
+                "충남 공주시 웅진로 10"
+        );
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "FD6",
+                ANCHOR_LONGITUDE,
+                ANCHOR_LATITUDE,
+                2000
+        )).thenReturn(List.of(food));
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "CE7",
+                ANCHOR_LONGITUDE,
+                ANCHOR_LATITUDE,
+                2000
+        )).thenReturn(List.of());
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "CE7",
+                ANCHOR_LONGITUDE,
+                ANCHOR_LATITUDE,
+                5000
+        )).thenReturn(List.of());
+
+        // when
+        CourseRecommendResponse response =
+                courseRecommendService.recommendCourses(
+                        REGION_ID,
+                        ANCHOR_ID
                 );
+
+        // then
+        assertThat(response.courses()).hasSize(1);
+
+        assertThat(response.courses().get(0).places())
+                .extracting(CoursePlaceResponse::title)
+                .contains("공주 DB 카페");
+    }
+
+    @Test
+    @DisplayName("관광지가 아닌 대표 장소는 Anchor로 사용할 수 없다")
+    void recommendRejectsNonTourismAnchor() {
+        // given
+        when(regionRepository.existsById(REGION_ID))
+                .thenReturn(true);
+
+        when(placeRepository.findByRegionIdAndRepresentativeTrue(REGION_ID))
+                .thenReturn(List.of(anchor));
+
+        when(placeRepository.findById(ANCHOR_ID))
+                .thenReturn(Optional.of(anchor));
+
+        when(anchor.getRegion())
+                .thenReturn(region);
+
+        when(region.getId())
+                .thenReturn(REGION_ID);
+
+        when(anchor.isRepresentative())
+                .thenReturn(true);
+
+        when(anchor.getCategoryGroup())
+                .thenReturn(PlaceCategoryGroup.FOOD);
+
+        // when & then
+        assertThatThrownBy(() ->
+                courseRecommendService.recommendCourses(
+                        REGION_ID,
+                        ANCHOR_ID
+                )
+        )
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(
+                        "추천 코스의 앵커 장소는 관광지 유형이어야 합니다."
+                );
+    }
+
+    @Test
+    @DisplayName("첫 번째 Anchor 코스가 제외되면 실제 첫 추천 코스의 Anchor ID를 반환한다")
+    void recommendUsesFirstValidAnchorIdAfterFilteringIncompleteCourse() {
+        // given
+        Place firstAnchor = org.mockito.Mockito.mock(Place.class);
+        Place secondAnchor = org.mockito.Mockito.mock(Place.class);
+
+        mockRegionAnchor(
+                firstAnchor,
+                10L,
+                "첫 번째 관광지",
+                PlaceCategoryDetail.HERITAGE,
+                "36.4500",
+                "127.1200"
+        );
+
+        mockRegionAnchor(
+                secondAnchor,
+                20L,
+                "두 번째 관광지",
+                PlaceCategoryDetail.NATURE,
+                "36.4600",
+                "127.1300"
+        );
+
+        when(regionRepository.existsById(REGION_ID))
+                .thenReturn(true);
+
+        when(placeRepository.findByRegionIdAndRepresentativeTrue(REGION_ID))
+                .thenReturn(List.of(firstAnchor, secondAnchor));
+
+        // 첫 번째 Anchor: FOOD/CAFE 모두 실패 → 불완전 코스
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "FD6",
+                new BigDecimal("127.1200"),
+                new BigDecimal("36.4500"),
+                2000
+        )).thenReturn(List.of());
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "FD6",
+                new BigDecimal("127.1200"),
+                new BigDecimal("36.4500"),
+                5000
+        )).thenReturn(List.of());
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "CE7",
+                new BigDecimal("127.1200"),
+                new BigDecimal("36.4500"),
+                2000
+        )).thenReturn(List.of());
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "CE7",
+                new BigDecimal("127.1200"),
+                new BigDecimal("36.4500"),
+                5000
+        )).thenReturn(List.of());
+
+        // 두 번째 Anchor: 정상 FOOD / CAFE 후보 존재
+        KakaoPlaceItem food = createKakaoPlace(
+                "food-2",
+                "두 번째 식당",
+                "FD6",
+                "충남 공주시 웅진로 30"
+        );
+
+        KakaoPlaceItem cafe = createKakaoPlace(
+                "cafe-2",
+                "두 번째 카페",
+                "CE7",
+                "충남 공주시 웅진로 40"
+        );
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "FD6",
+                new BigDecimal("127.1300"),
+                new BigDecimal("36.4600"),
+                2000
+        )).thenReturn(List.of(food));
+
+        when(kakaoLocalClient.searchPlacesByCategory(
+                "CE7",
+                new BigDecimal("127.1300"),
+                new BigDecimal("36.4600"),
+                2000
+        )).thenReturn(List.of(cafe));
+
+        // when
+        CourseRecommendResponse response =
+                courseRecommendService.recommendCourses(
+                        REGION_ID,
+                        null
+                );
+
+        // then
+        assertThat(response.courses()).hasSize(1);
+        assertThat(response.anchorPlaceId()).isEqualTo(20L);
+        assertThat(response.courses().get(0).places())
+                .extracting(CoursePlaceResponse::title)
+                .contains(
+                        "두 번째 관광지",
+                        "두 번째 식당",
+                        "두 번째 카페"
+                );
+    }
+
+    private void mockRegionAnchor(
+            Place place,
+            Long id,
+            String title,
+            PlaceCategoryDetail categoryDetail,
+            String latitude,
+            String longitude
+    ) {
+        when(place.getId()).thenReturn(id);
+        when(place.getRegion()).thenReturn(region);
+        when(place.getLatitude()).thenReturn(new BigDecimal(latitude));
+        when(place.getLongitude()).thenReturn(new BigDecimal(longitude));
+        when(place.getTitle()).thenReturn(title);
+        when(place.getAddress()).thenReturn("충남 공주시");
+        when(place.getCategoryGroup()).thenReturn(PlaceCategoryGroup.TOURISM);
+        when(place.getCategoryDetail()).thenReturn(categoryDetail);
+        when(place.getSource()).thenReturn(PlaceSource.TOUR_API);
+
+        when(region.getCityCountyName())
+                .thenReturn("공주시");
     }
 
     private void mockAnchor() {
@@ -349,20 +638,20 @@ class CourseRecommendServiceTest {
                 .thenReturn("126204");
     }
 
-    private void mockEmptyCafeSearch() {
-        when(kakaoLocalClient.searchPlacesByCategory(
+    private void mockDefaultCafeSearch() {
+        KakaoPlaceItem cafe = createKakaoPlace(
+                "cafe-1",
+                "공주 카페",
                 "CE7",
-                ANCHOR_LONGITUDE,
-                ANCHOR_LATITUDE,
-                2000
-        )).thenReturn(List.of());
+                "충남 공주시 웅진로 20"
+        );
 
         when(kakaoLocalClient.searchPlacesByCategory(
                 "CE7",
                 ANCHOR_LONGITUDE,
                 ANCHOR_LATITUDE,
-                5000
-        )).thenReturn(List.of());
+                2000
+        )).thenReturn(List.of(cafe));
     }
 
     private KakaoPlaceItem createKakaoPlace(
@@ -371,12 +660,14 @@ class CourseRecommendServiceTest {
             String categoryGroupCode,
             String address
     ) {
+        boolean isCafe = "CE7".equals(categoryGroupCode);
+
         return new KakaoPlaceItem(
                 id,
                 placeName,
-                "음식점 > 한식",
+                isCafe ? "카페 > 커피전문점" : "음식점 > 한식",
                 categoryGroupCode,
-                "음식점",
+                isCafe ? "카페" : "음식점",
                 address,
                 address,
                 "127.1200",


### PR DESCRIPTION
## ✨ 변경 사항

- 추천 코스가 `TOURISM`, `FOOD`, `CAFE_DESSERT` 각 1곳으로 구성되도록 검증 강화
- 음식점·카페 후보 조회 실패 시 동일 관광 유형의 대표 장소만 fallback으로 사용하도록 수정
- 3개 유형을 충족하지 못하는 불완전한 추천 코스 제외 처리
- 코스 앵커 장소를 `TOURISM` 유형으로 제한
- 코스 저장 시 실제 `Place.categoryGroup` 기준으로 최종 3분류 구성 검증
- 코스 장소 3곳 초과 요청 조기 차단
- 추천 및 저장 분류 검증 관련 테스트 보강

## 📌 담당 영역

- [ ] 공통 설정 / 인프라
- [x] Backend 1: 사용자·관광 데이터·코스/Odii
- [ ] Backend 2: 방문 인증·필름 롤·미디어 생성
- [ ] DB / Supabase
- [ ] 문서 / 기타

## 🔗 관련 이슈

- closes #94 

## 🧩 API / DB 변경 사항

- API 경로 및 요청/응답 스키마 변경 없음
- 잘못된 코스 3분류 구성 저장 시 `COURSE_017` 오류 응답 추가
- DB 변경 없음

## ✅ 테스트

- [x] 서버 실행 확인
- [x] Swagger 확인
- [x] 수동 테스트 완료
- [ ] 해당 없음

## 💬 참고 사항

- Swagger에서 추천 코스가 `TOURISM 1 + FOOD 1 + CAFE_DESSERT 1`로 반환되는 것 확인
- 코스 저장 검증은 실제 저장 대상 `Place`의 관광 유형을 기준으로 처리하여 요청값 조작 시에도 잘못된 조합 저장 방지
- 전체 테스트 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 추천 코스가 관광지·음식점·카페/디저트 각 1곳으로 구성된 경우에만 제공됩니다.
  * 음식점이나 카페 검색 결과가 없을 때 적합한 대체 장소를 활용합니다.
* **버그 수정**
  * 관광지가 아닌 앵커 장소로 추천 코스를 생성하는 문제가 방지됩니다.
  * 불완전하거나 잘못 구성된 코스의 저장이 거부됩니다.
  * 코스 장소가 허용된 개수를 초과하는 경우 저장 전에 안내됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->