### PR TITLE
🚀 [기능추가][Notification] iOS FCM 푸시 알림 지원

### DIFF
--- a/src/main/java/com/chaerok/backend/notification/device/entity/PushPlatform.java
+++ b/src/main/java/com/chaerok/backend/notification/device/entity/PushPlatform.java
@@ -1,5 +1,6 @@
 package com.chaerok.backend.notification.device.entity;
 
 public enum PushPlatform {
-    ANDROID
+    ANDROID,
+    IOS
 }

--- a/src/main/java/com/chaerok/backend/notification/sender/FirebasePushSender.java
+++ b/src/main/java/com/chaerok/backend/notification/sender/FirebasePushSender.java
@@ -6,10 +6,13 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.AndroidConfig;
 import com.google.firebase.messaging.AndroidNotification;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.Notification;
 import com.chaerok.backend.notification.message.NotificationPayload;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -61,6 +64,12 @@ public class FirebasePushSender implements PushSender {
             Message message = Message.builder()
                     .setToken(registrationToken)
                     .putAllData(payload.data())
+                    .setNotification(
+                            Notification.builder()
+                                    .setTitle(payload.title())
+                                    .setBody(payload.body())
+                                    .build()
+                    )
                     .setAndroidConfig(
                             AndroidConfig.builder()
                                     .setCollapseKey(
@@ -80,6 +89,27 @@ public class FirebasePushSender implements PushSender {
                                                     .setTag(
                                                             payload.notificationTag()
                                                     )
+                                                    .build()
+                                    )
+                                    .build()
+                    )
+                    .setApnsConfig(
+                            ApnsConfig.builder()
+                                    .putHeader(
+                                            "apns-push-type",
+                                            "alert"
+                                    )
+                                    .putHeader(
+                                            "apns-priority",
+                                            "10"
+                                    )
+                                    .putHeader(
+                                            "apns-collapse-id",
+                                            payload.collapseKey()
+                                    )
+                                    .setAps(
+                                            Aps.builder()
+                                                    .setSound("default")
                                                     .build()
                                     )
                                     .build()

--- a/src/test/java/com/chaerok/backend/notification/device/controller/PushDeviceControllerTest.java
+++ b/src/test/java/com/chaerok/backend/notification/device/controller/PushDeviceControllerTest.java
@@ -55,6 +55,26 @@ class PushDeviceControllerTest {
     }
 
     @Test
+    @DisplayName("현재 사용자의 iOS FCM 토큰을 등록하고 204를 반환한다")
+    void registerIos() {
+        ResponseEntity<Void> response = controller.register(
+                authenticatedUser,
+                new PushDeviceRegisterRequest(
+                        "ios-token-1",
+                        PushPlatform.IOS
+                )
+        );
+
+        assertThat(response.getStatusCode())
+                .isEqualTo(HttpStatus.NO_CONTENT);
+        verify(pushDeviceService).register(
+                6L,
+                "ios-token-1",
+                PushPlatform.IOS
+        );
+    }
+
+    @Test
     @DisplayName("현재 사용자의 FCM 토큰을 해제하고 204를 반환한다")
     void unregister() {
         ResponseEntity<Void> response = controller.unregister(


### PR DESCRIPTION
## ✨ 변경 사항

* FCM 푸시 플랫폼에 iOS 지원 추가
* Android/iOS 공통 알림 title, body 설정 추가
* iOS용 APNs 설정 추가
* 기존 Android FCM 전송 방식 유지
* iOS FCM 토큰 등록 테스트 추가

## 📌 담당 영역

* [ ] 공통 설정 / 인프라
* [ ] Backend 1: 사용자·관광 데이터·코스/Odii
* [x] Backend 2: 방문 인증·필름 롤·미디어 생성
* [ ] DB / Supabase
* [ ] 문서 / 기타

## 🔗 관련 이슈

* closes #99

## 🧩 API / DB 변경 사항

* 기존 푸시 디바이스 등록 API에서 `platform: "IOS"` 지원
* 신규 API 없음
* DB 변경 없음
* Migration 추가 없음

## ✅ 테스트

* [x] 서버 실행 확인

* [ ] Swagger 확인

* [x] 수동 테스트 완료

* [ ] 해당 없음

* Notification 관련 테스트 성공

* 전체 백엔드 테스트 성공

* 기존 Android FCM 동작 유지 확인

* iOS FCM 토큰 등록 테스트 확인

## 💬 참고 사항

* 기존 Notification Outbox, Dispatcher, 재시도 및 무효 토큰 처리 로직은 변경하지 않았습니다.
* PR #91의 `BusinessException`, `ErrorCode`, `GlobalExceptionHandler` 기반 예외처리 구조를 그대로 유지합니다.
* 실제 iOS 기기 푸시 수신을 위해서는 프론트엔드의 iOS FCM 토큰 등록 및 Firebase/APNs 설정이 별도로 필요합니다.
